### PR TITLE
Feat/paragraph width

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "typescript": "^4.1.3"
   }
 }

--- a/src/Paragraphs.tsx
+++ b/src/Paragraphs.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import * as React from "react";
 import Accord from "./Accord";
 import SingleCard from "./SingleCard";
@@ -77,12 +76,21 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-function Paragraphs(props) {
+interface ParagraphsProps {
+  paragraphs: any,
+  site: string,
+  type: string;
+  title: string;
+  text: string;
+  width: "Narrow" | "Medium" | "Wide" | "Full" | null;
+}
+
+function Paragraphs(props: ParagraphsProps) {
     const classes = useStyles();
     const { paragraphs, site, width } = props;
     console.log(width);
-    const items = [];
-    paragraphs.map((paragraph, index) => {
+    const items:any[] = [];
+    paragraphs.map((paragraph: any, index: number) => {
 
         switch(paragraph.type) {
             case 'Accordion':
@@ -206,16 +214,5 @@ function Paragraphs(props) {
         </React.Fragment>
     );
 }
-
-Paragraphs.propTypes = {
-    paragraphs: PropTypes.arrayOf(
-        PropTypes.shape({
-            type: PropTypes.string.isRequired,
-            title: PropTypes.string.isRequired,
-            text: PropTypes.string.isRequired,
-            width: PropTypes.number.isRequired,
-        }),
-    ).isRequired,
-};
 
 export default Paragraphs;

--- a/src/Paragraphs.tsx
+++ b/src/Paragraphs.tsx
@@ -7,20 +7,20 @@ import Pdf from "./Pdf";
 import PhoneNumberBox from "./PhoneNumberBox";
 import Text from "./Text";
 import Grid from "@material-ui/core/Grid";
-import {makeStyles} from "@material-ui/core/styles";
-import Hidden from '@material-ui/core/Hidden';
+import { makeStyles } from "@material-ui/core/styles";
 import Image from "./Image";
 import ImageAndCard from "./ImageAndCard";
 import CardList from "./CardList";
+import { Container } from "hds-react";
 
 const useStyles = makeStyles((theme) => ({
   container: {
     padding: 0,
-    marginTop: 0,
-    marginBottom: 16,
-    [theme.breakpoints.only("xs")]: {
+    margin: "0 auto 16px auto",
+    [theme.breakpoints.down(768)]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
+      maxWidth: "100%",
     },
   },
   accord: {
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: 0,
     [theme.breakpoints.only("xs")]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
     },
   },
   card: {
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: 15,
     [theme.breakpoints.only("xs")]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
     },
   },
   subheading: {
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: 15,
     [theme.breakpoints.only("xs")]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
     },
   },
   info: {
@@ -65,154 +65,172 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
     [theme.breakpoints.only("xs")]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
     },
   },
   sides: {
     [theme.breakpoints.only("xs")]: {
       paddingLeft: 16,
-      paddingRight: 16
+      paddingRight: 16,
     },
-  }
+  },
 }));
 
+type ParagraphWidth = "Narrow" | "Medium" | "Wide" | "Full" | null;
+
 interface ParagraphsProps {
-  paragraphs: any,
-  site: string,
+  paragraphs: any;
+  site: string;
   type: string;
   title: string;
   text: string;
-  width: "Narrow" | "Medium" | "Wide" | "Full" | null;
+  width: ParagraphWidth;
 }
 
-function Paragraphs(props: ParagraphsProps) {
-    const classes = useStyles();
-    const { paragraphs, site, width } = props;
-    console.log(width);
-    const items:any[] = [];
-    paragraphs.map((paragraph: any, index: number) => {
+const WideParagraphGrid = ({ className, children }: { className: string; children: any }) => (
+  <Grid container spacing={1} className={className}>
+    <Grid item style={{ margin: "0 auto" }} xs={12}>
+      {children}
+    </Grid>
+  </Grid>
+);
 
-        switch(paragraph.type) {
-            case 'Accordion':
-                items.push(
-                  <Grid container spacing={1} className={classes.accord} key={index}>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                    <Grid item xs={12} sm={6} key={2}>
-                        <Accord key={index} {...paragraph}></Accord>
-                    </Grid>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-                  </Grid>
-                );
-                break;
-            case 'Card':
-              items.push(
-                <Grid container spacing={1} className={classes.card} key={index}>
-                  <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                  <Grid item xs={12} sm={6} key={2}>
-                    <SingleCard key={index} {...paragraph}></SingleCard>
-                  </Grid>
-                  <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-                </Grid>
-              );
-              break;
-          case 'CardList':
-            items.push(
-              <Grid container spacing={1} className={classes.card} key={index}>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                <Grid item xs={12} sm={9} key={2}>
-                  <CardList key={index} {...paragraph}></CardList>
-                </Grid>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-              </Grid>
-            );
-            break;
-            case 'Subheading':
-                items.push(
-                  <Grid container spacing={1} className={classes.subheading} key={index}>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                    <Grid item xs={12} sm={6} key={2}>
-                        <Subheading key={index} {...paragraph}></Subheading>
-                    </Grid>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-                  </Grid>
-                );
-                break;
-            case 'Info':
-                items.push(
-                  <Grid container spacing={1} className={classes.info} key={index}>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                      <Grid item xs={12} sm={7} key={2}>
-                        <Info key={index} {...paragraph}></Info>
-                      </Grid>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-                  </Grid>
-                );
-                break;
-            case 'Pdf':
-            case 'PDF':
-                items.push(
-                  <Grid container spacing={1} className={classes.pdf} key={index}>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                    <Grid item xs={12} sm={6} key={2}>
-                        <Pdf key={index} {...paragraph} site={site}></Pdf>
-                    </Grid>
-                    <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-                  </Grid>
-                    );
-                break;
-          case 'Image':
-            items.push(
-              <Grid container spacing={1} className={classes.info} key={index}>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                <Grid item xs={12} sm={6} key={2}>
-                  <Image key={index} {...paragraph} site={site}></Image>
-                </Grid>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-              </Grid>
-            );
-            break;
-          case 'ImageAndCard':
-            items.push(
-              <Grid container spacing={1} className={classes.info} key={index}>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                <Grid item xs={12} sm={8} key={2}>
-                  <ImageAndCard key={index} {...paragraph} site={site}></ImageAndCard>
-                </Grid>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-              </Grid>
-            );
-            break;
-          case 'PhoneNumberBox':
-            items.push(
-              <Grid container spacing={1} className={classes.card} key={index}>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                <Grid item xs={12} sm={6} key={2}>
-                  <PhoneNumberBox key={index} {...paragraph}></PhoneNumberBox>
-                </Grid>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-              </Grid>
-            );
-            break;
-          case 'Text':
-            items.push(
-              <Grid container spacing={1} className={classes.accord} key={index}>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={1}></Grid></Hidden>
-                <Grid item xs={12} sm={6} key={2}>
-                    <Text key={index} {...paragraph}></Text>
-                </Grid>
-                <Hidden only={'xs'}><Grid item xs className={classes.sides} key={3}></Grid></Hidden>
-              </Grid>
-            );
-            break;
-          default: break;
-        }
-        return items;
-    });
-    return (
-        <React.Fragment>
-            {items}
-        </React.Fragment>
-    );
+const NarrowParagraphGrid = ({ className, children }: { className: string; children: any }) => (
+  <Grid container spacing={1} className={className}>
+    <Grid item style={{ margin: "0 auto" }} xs={12} md={8}>
+      {children}
+    </Grid>
+  </Grid>
+);
+
+const NarrowLargerParagraphGrid = ({ className, children }: { className: string; children: any }) => (
+  <Grid container spacing={1} className={className}>
+    <Grid item style={{ margin: "0 auto" }} xs={12} md={9}>
+      {children}
+    </Grid>
+  </Grid>
+);
+
+export const DefaultParagraphGrid = ({ className, children }: { className: string; children: any }) => (
+  <Grid container spacing={1} className={className}>
+    <Grid item style={{ margin: "0 auto" }} xs={12} md={8} key={2}>
+      {children}
+    </Grid>
+  </Grid>
+);
+
+const ParagraphGrid = ({
+  className,
+  paragraphWidth,
+  children,
+}: {
+  className: string;
+  paragraphWidth: ParagraphWidth;
+  children: any;
+}) => {
+  if (paragraphWidth !== "Narrow") {
+    return <WideParagraphGrid className={className}>{children}</WideParagraphGrid>;
+  }
+  return <NarrowParagraphGrid className={className}>{children}</NarrowParagraphGrid>;
+};
+
+function Paragraphs(props: ParagraphsProps) {
+  const classes = useStyles();
+  const { paragraphs, site, width } = props;
+  console.log(width);
+  const items: any[] = [];
+  paragraphs.map((paragraph: any, index: number) => {
+    switch (paragraph.type) {
+      case "Accordion":
+        items.push(
+          <ParagraphGrid className={classes.accord} paragraphWidth={props.width}>
+            <Accord key={index} {...paragraph}></Accord>
+          </ParagraphGrid>
+        );
+        break;
+      case "Card":
+        items.push(
+          <ParagraphGrid className={classes.card} paragraphWidth={props.width}>
+            <SingleCard key={index} {...paragraph}></SingleCard>
+          </ParagraphGrid>
+        );
+        break;
+      case "CardList":
+        items.push(
+          <ParagraphGrid className={classes.card} paragraphWidth={props.width}>
+            <CardList key={index} {...paragraph}></CardList>
+          </ParagraphGrid>
+        );
+        break;
+      case "Subheading":
+        items.push(
+          <ParagraphGrid className={classes.subheading} paragraphWidth={props.width}>
+            <Subheading key={index} {...paragraph}></Subheading>
+          </ParagraphGrid>
+        );
+        break;
+      case "Info":
+        items.push(
+          props.width === "Narrow" ? (
+            <NarrowLargerParagraphGrid className={classes.info}>
+              <Info key={index} {...paragraph}></Info>
+            </NarrowLargerParagraphGrid>
+          ) : (
+            <ParagraphGrid className={classes.info} paragraphWidth={props.width}>
+              <Info key={index} {...paragraph}></Info>
+            </ParagraphGrid>
+          )
+        );
+        break;
+      case "Pdf":
+      case "PDF":
+        items.push(
+          <ParagraphGrid className={classes.pdf} paragraphWidth={props.width}>
+            <Pdf key={index} {...paragraph} site={site}></Pdf>
+          </ParagraphGrid>
+        );
+        break;
+      case "Image":
+        items.push(
+          <ParagraphGrid className={classes.info} paragraphWidth={props.width}>
+            <Image key={index} {...paragraph} site={site}></Image>
+          </ParagraphGrid>
+        );
+        break;
+      case "ImageAndCard":
+        items.push(
+          <ParagraphGrid className={classes.info} paragraphWidth={props.width}>
+            <ImageAndCard key={index} {...paragraph} site={site}></ImageAndCard>
+          </ParagraphGrid>
+        );
+        break;
+      case "PhoneNumberBox":
+        items.push(
+          <ParagraphGrid className={classes.card} paragraphWidth={props.width}>
+            <PhoneNumberBox key={index} {...paragraph}></PhoneNumberBox>
+          </ParagraphGrid>
+        );
+        break;
+      case "Text":
+        items.push(
+          <ParagraphGrid className={classes.accord} paragraphWidth={props.width}>
+            <Text key={index} {...paragraph}></Text>
+          </ParagraphGrid>
+        );
+        break;
+      default:
+        break;
+    }
+    return;
+  });
+
+  return (
+    <React.Fragment>
+      {items.map((item) => {
+        return <Container className={classes.container}>{item}</Container>;
+      })}
+    </React.Fragment>
+  );
 }
 
 export default Paragraphs;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11236,6 +11236,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
## Changes

### Use typescript

Refactored Paragraphs.js to use TypeScript. We can gradually start using it.

### Refactor grid layout system

Use 'Container' to wrap content. This should adjust accordingly with screen width. Use 'Grid' inside the 'Container' wrapper. For Paragraph 'Wide' use 12/12 grid size on large and smaller screen widths. For 'Narrow' 8/12 on larger screen widths and 12/12 on smaller larger screen widths. The Info paragrapg is handled as an exception and will be 9/12 for 'Narrow'. Some refactoring is needed in the future.

*Note:* currently supports only 'Narrow' and 'Wide' sizes for Paragraph width. We could remove the extra ones from Drupal if not needed ATM? :thinking: 