### PR TITLE
hero set to use its own title

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -8,13 +8,13 @@ import styles from './hero.module.scss'
 
 
 interface HeroProps {
-  title: string
+  field_hero_title: string
   field_hero_desc: DrupalFormattedText
   field_custom_hero_image: any
 }
 
 function Hero(props: HeroProps): JSX.Element {
-  const { title, field_hero_desc, field_custom_hero_image } = props
+  const { field_hero_title, field_hero_desc, field_custom_hero_image } = props
   const rootKorosStyle = { '--koros-height': '120px', '--hero-height': '480px', '--hero-width': '950px' };
 
   return (
@@ -22,10 +22,12 @@ function Hero(props: HeroProps): JSX.Element {
       <div className={styles.heroContainer}>
         <div className={styles.heroTextContainer}>
           <div className={styles.heroTextContent}>
-            <h1>{title}</h1>
-            { field_hero_desc && 
+            { field_hero_title &&
+              <h1>{field_hero_title}</h1>
+            }
+            { field_hero_desc &&
               <HtmlBlock field_text={field_hero_desc} />
-            }      
+            }
           </div>
           <Koros
             className={styles.heroMobileKoros}
@@ -40,7 +42,7 @@ function Hero(props: HeroProps): JSX.Element {
           <span className={styles.heroArrow} aria-hidden='true'>
             <IconArrowDown
               size="xl"
-              style={{ 
+              style={{
                 color: 'var(--color-metro)',
                 width: '150px',
                 height: '150px'

--- a/src/components/pageTemplates/NodeLandingPage.tsx
+++ b/src/components/pageTemplates/NodeLandingPage.tsx
@@ -13,7 +13,7 @@ export function NodeLandingPage({ node, ...props }: NodeLandingPageProps): JSX.E
   return (
     <article>
       {field_hero && (
-        <Hero title={title} {...field_hero} />
+        <Hero {...field_hero} />
       )}
       <Container className="container">
         <div className="columns">

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -88,6 +88,7 @@ const getLandingPageQueryParams = () =>
       'field_hero.field_custom_hero_image.field_media_image'
     ])
     .addFields(CONTENT_TYPES.HERO, [
+      'field_hero_title',
       'field_hero_desc',
       'field_custom_hero_image'
     ])

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ import {
 export interface Node extends DrupalNode {
   title: string
   field_hero?: {
+    field_hero_title: string
     field_hero_desc: DrupalFormattedText
     field_custom_hero_image: any
   }


### PR DESCRIPTION
Hero component was modified to use hero_title rather than title which was the title of landing page. so now we can have one title for Hero itself and another for landing page.