### PR TITLE
THF-307: list of links with image on basic page

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -304,10 +304,6 @@ h5, .h5,
 }
 
 @media (min-width: $breakpoint-m) {
-  .content-region .link-box {
-    width: calc(33.33% - var(--spacing-l));
-  }
-
   main h1, main .h1 {
     font-size: var(--fontsize-heading-xl);
     line-height: var(--lineheight-m);
@@ -378,9 +374,5 @@ h5, .h5,
 
   .col-12 {
     width: 100%;
-  }
-
-  .content-region .link-box {
-    width: calc(33.33% - var(--spacing-l));
   }
 }


### PR DESCRIPTION
Change that list of links: link with image shows only two items side by side on basic page. Can be found from Koulutusneuvonta page.

<img width="894" alt="Screenshot 2022-08-22 at 9 25 27" src="https://user-images.githubusercontent.com/51796892/185853135-4ef22d0a-9d2e-4a2b-ab05-329a90e3530a.png">
