### PR TITLE
THF-299: Events breadcrumb

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -92,7 +92,7 @@ export async function getStaticProps(context: GetStaticPropsContext): Promise<Ge
   const { tree: themes } = await getMenu('additional-languages', locale, defaultLocale)
   const { tree: footerNav } = await getMenu('footer', locale, defaultLocale)
 
-  const breadcrumb = getBreadCrumb(menuItems, node?.path.alias, node?.title)
+  const breadcrumb = getBreadCrumb(menuItems, node?.path.alias, node?.title, node?.type)
 
   return {
     props: {

--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -65,7 +65,7 @@ export function EventList({ pageType, ...props }: EventListProps): JSX.Element {
                 linkboxAriaLabel="List of links Linkbox"
                 linkAriaLabel="Linkbox link"
                 key={key}
-                href={`${t('list.events_page_url')}${getPath(event.path.alias)}`}
+                href={event.path.alias}
                 withBorder
               >
                 <Image
@@ -182,7 +182,7 @@ export function EventListWithFilters(props: EventListProps): JSX.Element {
                 linkboxAriaLabel="List of links Linkbox"
                 linkAriaLabel="Linkbox link"
                 key={key}
-                href={`${t('list.events_page_url')}${getPath(event.url[0])}`}
+                href=getPath(event.url[0])}
                 withBorder
               >
                 <Image

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -60,7 +60,7 @@ function NewsList(props: NewsListProps): JSX.Element {
         <div className={`${styles.newsList} ${field_short_list && styles.short}`}>
           { paginatedNews && paginatedNews.map((news: any, key: any) => (
             <div className={styles.newsCard} key={key}>
-                <a href={`${t('list.news_url')}${getPath(news.path.alias)}`}>
+                <a href={news.path.alias}>
                   <h3 className={styles.newsTitle}>{news.title}</h3>
                 </a>
               <p className={styles.articleDate}><time dateTime={news.created}>{`${dateformat(news.created, 'dd.mm.yyyy')}`}</time></p>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -23,11 +23,10 @@ export const getImageUrl = (url: string): string => {
   return url ? `https://${host}${url}` : ''
 }
 
-export const getPath = (url: string) => {
-  const urlParts =  url.split('/')
-  const newsPath = urlParts.pop()
+export const getPath = (url: string): string => {
+  const newUrl = new URL(url)
 
-  return (`/${newsPath}`)
+  return (newUrl.pathname)
 }
 
 export async function getLanguageLinks(node: DrupalNode): Promise<Object> {


### PR DESCRIPTION
- Updated React to use path alias coming from Drupal instead of using translated paths.
- Works only with Finnish translations.
- Events should have now "Tapahtumakalenteri" as the parent, hence the breadcrumb remains up-to-date.