### PR TITLE
THF-311: Adding front page link for the site logo

### DIFF
--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -87,6 +87,7 @@ function Header(header:NavProps): JSX.Element {
       skipToContentLabel="Skip to main content"
       title={t('site_name')}
       titleAriaLabel={t('navigation.title_aria_label')}
+      titleUrl={locale === 'fi' ? '/' : `/${locale}`}
       className={classNames(styles.navigation, styles.zover)}
     >
       <Navigation.Row>


### PR DESCRIPTION
- Clicking the logo will now point to the site's front page.
- Works with language prefix