### PR TITLE
THF-377: Setting cookieDomain instead using global setting.

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -50,6 +50,7 @@ export const useCookieConsents = (): any => {
       onLanguageChange,
     },
     focusTargetSelector: '#focused-element-after-cookie-consent-closed',
+    CookieDomain: 'tyollisyyspalvelut.hel.fi',
     optionalCookies: {
       groups: [
         {


### PR DESCRIPTION
- Updated cookie consent component with CookieDomain option to prevent hel.fi site to delete unknown cookie.