### PR TITLE
THF-405: Recreated Events search functionality.

### DIFF
--- a/pages/api/events-search.ts
+++ b/pages/api/events-search.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return
   }
 
-  const { index }: Index = req?.query
+  const { index, filter }: Index = req?.query
 
   if (isNaN(Number(index))) {
     res.status(400)
@@ -23,12 +23,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   const elastic = Elastic.getElasticClient()
 
+  let response: any = {}
   const body = {
     size: 9,
     from: (9*Number(index)),
-    query: {
-      match_all: {}
-    }
+    query: filter ? { match: { field_tags: String(filter) } } : { match_all: {} }
   }
 
   try {
@@ -42,15 +41,47 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       hits: { total, hits }
     } = searchRes as { hits: { total: SearchTotalHits, hits: SearchHit<unknown>[] }}
 
-    res.json({
+    Object.assign(response, {
       total: total?.value,
       events: hits.map((hit: any) => {
         const { title, url, field_image_url, field_image_alt, field_start_time, field_end_time, field_location, field_tags, field_street_address } = hit._source as EventData
         return { title, url, field_image_url, field_image_alt, field_start_time, field_end_time, field_location, field_tags, field_street_address }
       }),
     })
+
   } catch (err) {
     console.log('err', err)
     res.status(500)
   }
+
+  /**
+   * @TODO Is there better way to get static info about the tags and total amount of all events for filters?
+   */
+  if (filter) {
+    try {
+      const searchRes = await elastic.search({
+        index: 'events_fi',
+        body: { query: { match_all: {} } },
+        sort: "field_end_time:asc"
+      })
+
+      const {
+        hits: { total, hits }
+      } = searchRes as { hits: { total: SearchTotalHits, hits: SearchHit<unknown>[] }}
+
+      Object.assign(response, {
+        maxTotal: total?.value,
+        tags: hits.map((hit: any) => {
+          const { field_tags } = hit._source as EventData
+          return { field_tags }
+        }),
+      })
+
+    } catch (err) {
+      console.log('err', err)
+      res.status(500)
+    }
+  }
+
+  res.json(response)
 }

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -7,13 +7,14 @@ import Accordion from '@/components/accordion/Accordion'
 import Banner from '@/components/banner/Banner'
 import LiftupWithImage from '@/components/liftupWithImage/LiftupWithImage'
 import Notification from '@/components/notification/Notification'
-import { EventList, EventListWithFilters } from '@/components/events/EventList'
+import { EventList } from '@/components/events/EventList'
 import NewsList from '@/components/news/NewsList'
 import ParagraphImage from '@/components/paragraphImage/ParagraphImage'
 import Quote from '@/components/quote/Quote'
 import SujoEmbedded from '@/components/sujoEmbedded/sujoEmbedded'
 import UnitsList from './tprUnits/UnitsList'
 import MapEmbedded from './mapEmbedded/MapEmbedded'
+import Events from './events/Events'
 
 
 interface ContentMapperProps {
@@ -88,7 +89,7 @@ export function ContentMapper({ content, pageType, locationId, mapId, langcode, 
         if (item.field_events_list_short) {
           return <EventList {...item} pageType={pageType} key={key} locationId={locationId}/>
         }
-        return <EventListWithFilters {...item} key={key} />
+        return <Events {...item} key={key} />
 
       case CONTENT_TYPES.NEWS_LIST:
         if (!item?.id) {

--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import Image from 'next/image'
 import { Linkbox, Button as HDSButton, IconPlus, IconCrossCircle, IconArrowRight, Container } from 'hds-react'
 
-import { DrupalFormattedText, EventsQueryParams, EventState } from '@/lib/types'
+import { DrupalFormattedText, EventsQueryParams, EventState, EventListProps } from '@/lib/types'
 import { getEvents, getEventsSearch } from '@/lib/client-api'
 import { eventTags, getPath, getPathAlias } from '@/lib/helpers'
 
@@ -15,19 +15,6 @@ import TagList from './TagList'
 import DateTime from './DateTime'
 
 import styles from './events.module.scss'
-
-interface EventListProps {
-  pageType?: string
-  field_title: string
-  field_events_list_short: boolean
-  field_event_tag_filter: string[]
-  field_background_color: {
-    field_css_name: string
-  } | null
-  field_events_list_desc:  DrupalFormattedText
-  locationId: string | null
-  field_street_address: string
-}
 
 export function EventList({ pageType, locationId, ...props }: EventListProps): JSX.Element {
   const { field_title, field_events_list_short, field_event_tag_filter: tags, field_background_color, field_events_list_desc } = props
@@ -98,151 +85,6 @@ export function EventList({ pageType, locationId, ...props }: EventListProps): J
             : t('list.no_events')
           }
         </div>
-      </Container>
-    </div>
-  )
-}
-
-const getKey = (eventsIndex: number) => {
-  return `${eventsIndex}`
-}
-
-export function EventListWithFilters(props: EventListProps): JSX.Element {
-  const { field_title, field_events_list_desc } = props
-  const { t } = useTranslation()
-  const { locale } = useRouter()
-  const fetcher = (eventsIndex: number) => getEventsSearch(eventsIndex)
-  const { data, size, setSize } = useSWRInfinite(getKey, fetcher)
-  const [filter, setFilter] = useState<any | null>(t('search.clear'))
-  const [filteredEvents, setFilteredEvents] = useState<EventState>()
-
-  const events = data && data.reduce((acc:any, curr:any) => acc.concat(curr.events), [])
-  const total: Number = data && data.reduce((acc:any, r:any) => (r.total), 0)
-
-  const loadMoreText = t('list.load_more')
-  const resultsText = t('list.results_text')
-
-  /**
-   * @TODO Check ssr-api.js for maybe better solution via "getResourceByPath" or "translatePath"
-   */
-  const getLangPath = (event: any): string => {
-    const nodePath: string = event.url[0].substring(event.url[0].lastIndexOf('/'))
-    const eventPaths: any = {
-      'sv': '/sv/aktuellt/evenemang',
-      'en': '/en/current-matters/events'
-    }
-
-    return locale !== 'fi' && locale != undefined ? `${eventPaths[locale]}${nodePath}` : getPath(event.url[0])
-  }
-
-  useEffect(() => {
-    const filterEvents = () => {
-      const filtered = filter !== t('search.clear') ? events.filter((event: any) => event.field_tags.includes(filter)) : events
-      const fe: EventState = {
-        total: filtered && filtered.length,
-        events: filtered
-      }
-      setFilteredEvents(fe)
-    }
-    filterEvents()
-  }, [filter, data]) // eslint-disable-line
-
-  if (!data) return <></>
-
-  let tags = events && events.reduce((acc:any, curr:any) => {
-    return [...acc, curr.field_tags]
-  }, [])
-
-  tags = tags && tags.flat().filter((value:any, index:any, array:any) => {
-    return array.indexOf(value) === index
-  })
-  // Prioritise tags order by eventTags.
-  tags && tags.sort((a: string, b: string) => eventTags.indexOf(a) - eventTags.indexOf(b))
-  const finalTags = tags && tags.map((tag: string) => tag !== undefined && tag.replace('_', ' '))
-  finalTags && finalTags.push(t('search.clear'))
-
-  return (
-    <div className='component'>
-      <Container className='container'>
-        {field_title &&
-          <h2>{field_title}</h2>
-        }
-        {field_events_list_desc?.processed &&
-          <div className={styles.eventListDescription}>
-            <HtmlBlock field_text={field_events_list_desc} />
-          </div>
-        }
-        <div className={styles.results}>
-          {filter !== t('search.clear') ? `${filteredEvents?.total} / ${total} ${resultsText}` : `${total} ${resultsText}`}
-        </div>
-        <div className={styles.filter}>{t('search.filter')}</div>
-        <div className={styles.filterTags}>
-          {finalTags && Object.values(finalTags).map((tag: any, i: number) => (
-            tag === t('search.clear') ? (
-              <HDSButton
-                key={`tagFilter-${i}`}
-                variant="supplementary"
-                iconLeft={<IconCrossCircle />}
-                className={styles.supplementary}
-                onClick={() => {setFilter(tag)}}
-              >
-                {tag}
-              </HDSButton>
-            )
-            : (
-              <HDSButton
-                key={`tagFilter-${i}`}
-                className={filter === tag ? styles.selected: styles.filterTag}
-                onClick={() => {setFilter(tag.replace(' ', '_'))}}
-              >
-                {tag}
-              </HDSButton>
-            )
-          ))}
-        </div>
-        <div className={styles.eventList}>
-          { filteredEvents?.events && filteredEvents.events.map((event: any, key: any) => (
-            <div className={styles.eventCard} key={key}>
-              <Linkbox
-                className={styles.linkBox}
-                linkboxAriaLabel="List of links Linkbox"
-                linkAriaLabel="Linkbox link"
-                key={key}
-                href={getLangPath(event)}
-                withBorder
-              >
-                <Image
-                  src={event.field_image_url[0]}
-                  alt={event.field_image_alt[0]}
-                  layout='responsive'
-                  objectFit='cover'
-                  width={384}
-                  height={158}
-                />
-                <div className={styles.eventCardContent}>
-                  {event.field_tags && event.field_tags.length !== 0 && <TagList tags={event.field_tags} /> }
-                  <DateTime startTime={event.field_start_time[0]} endTime={event.field_end_time[0]} />
-                  <h3>{event.title[0]}</h3>
-                  <p>{event.field_location[0]}{ event.field_street_address ? `, ${event.field_street_address[0]}` : ''}</p>
-                </div>
-              </Linkbox>
-            </div>
-          ))}
-        </div>
-        {events && total > events.length && (
-          <div className={styles.loadMore}>
-            <HDSButton
-              variant='supplementary'
-              iconRight={<IconPlus />}
-              style={{ background: 'none' }}
-              onClick={() => {
-                setSize(size + 1)
-              }}
-            >
-              {loadMoreText}
-            </HDSButton>
-          </div>
-        )}
       </Container>
     </div>
   )

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -1,0 +1,164 @@
+import { getEventsSearch } from "@/lib/client-api"
+import { EventListProps } from "@/lib/types"
+import { Linkbox, Button as HDSButton, IconPlus, IconCrossCircle, IconArrowRight, Container } from "hds-react"
+import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
+import useSWRInfinite from 'swr/infinite'
+import HtmlBlock from "../HtmlBlock"
+import Image from 'next/image'
+
+import styles from './events.module.scss'
+import DateTime from "./DateTime"
+import TagList from "./TagList"
+import { eventTags, getPath } from "@/lib/helpers"
+import { useEffect, useState } from "react"
+
+const getKey = (eventsIndex: number) => {
+  return `${eventsIndex}`
+}
+
+const getTags = (props: any) => {
+  const { data, events } = props
+  const handler = data[0].tags ? data[0].tags : events
+
+  return handler
+    .reduce((acc:any, curr:any) => { 
+      return [...acc, curr.field_tags]
+        .flat()
+        .filter((value:any, index:any, array:any) => {
+          return array.indexOf(value) === index && value !== undefined})
+    }, [])
+    .sort((a: string, b: string) => eventTags.indexOf(a) - eventTags.indexOf(b))
+}
+
+const getEvents = (data: any) => {
+  return data.reduce((acc:any, curr:any) => acc.concat(curr.events), [])
+}
+
+const getTotal = (data: any) => {
+  return {
+    'max': data[0].maxTotal ? data[0].maxTotal : data[0].total,
+    'current': data[0].total
+  }
+}
+
+export default function Events(props: EventListProps): JSX.Element {
+  const { field_title, field_events_list_desc } = props
+  const { t } = useTranslation()
+  const { locale } = useRouter()
+  const [filter, setFilter] = useState<string | null>(null)
+
+  const fetcher = (eventsIndex: number) => getEventsSearch(eventsIndex, filter)
+  const { data, size, setSize } = useSWRInfinite(getKey, fetcher)
+  const events = data && getEvents(data)
+  const total = data && getTotal(data)
+  const tags = events && getTags({data, events})
+
+  const resultText = !total ? '' : total.current < total.max ? `${total.current} / ${total.max} ${t('list.results_text')}` : `${total.max} ${t('list.results_text')}`
+
+  /**
+   * @TODO Check ssr-api.js for maybe better solution via "getResourceByPath" or "translatePath"
+   */
+  const getLangPath = (event: any): string => {
+    const nodePath: string = event.url[0].substring(event.url[0].lastIndexOf('/'))
+    const eventPaths: any = {
+      'sv': '/sv/aktuellt/evenemang',
+      'en': '/en/current-matters/events'
+    }
+
+    return locale !== 'fi' && locale != undefined ? `${eventPaths[locale]}${nodePath}` : getPath(event.url[0])
+  }
+
+  useEffect(() => {
+    setSize(1)
+  }, [filter]) // eslint-disable-line
+
+  return (
+    <div className='component'>
+    <Container className='container'>
+      { field_title && 
+        <h2>{field_title}</h2> 
+      }
+
+      { field_events_list_desc?.processed &&
+        <div className={styles.eventListDescription}>
+          <HtmlBlock field_text={field_events_list_desc} />
+        </div>
+      }
+
+      <div className={styles.results}>
+        { resultText }  
+      </div>
+
+      <div className={styles.filter}>{t('search.filter')}</div>
+
+      <div className={styles.filterTags}>
+        { tags && tags.map((tag: any, i: number) => (
+          <HDSButton
+            key={`tagFilter-${i}`}
+            className={filter === tag ? styles.selected: styles.filterTag}
+            onClick={() => { setFilter(tag.replace(' ', '_')) }}
+          >
+            { tag.replace('_', ' ') }
+          </HDSButton>
+          ))
+        }
+        <HDSButton
+          variant="supplementary"
+          iconLeft={<IconCrossCircle />}
+          className={styles.supplementary}
+          onClick={() => { setFilter(null) }}
+        >
+          { t('search.clear') }
+        </HDSButton>
+      </div>
+
+      <div className={styles.eventList}>
+        { events && events.map((event: any, key: any) => (
+          <div className={styles.eventCard} key={key}>
+            <Linkbox
+              className={styles.linkBox}
+              linkboxAriaLabel="List of links Linkbox"
+              linkAriaLabel="Linkbox link"
+              key={key}
+              href={getLangPath(event)}
+              withBorder
+            >
+              <Image
+                src={event.field_image_url[0]}
+                alt={event.field_image_alt[0]}
+                layout='responsive'
+                objectFit='cover'
+                width={384}
+                height={158}
+              />
+              <div className={styles.eventCardContent}>
+                {event.field_tags && event.field_tags.length !== 0 && <TagList tags={event.field_tags} /> }
+                <DateTime startTime={event.field_start_time[0]} endTime={event.field_end_time[0]} />
+                <h3>{event.title[0]}</h3>
+                <p>{event.field_location[0]}{ event.field_street_address ? `, ${event.field_street_address[0]}` : ''}</p>
+              </div>
+            </Linkbox>
+          </div>
+        ))}
+      </div>
+
+      {events && total && total.current > (size*9) && (
+        <div className={styles.loadMore}>
+          <HDSButton
+            variant='supplementary'
+            iconRight={<IconPlus />}
+            style={{ background: 'none' }}
+            onClick={() => {
+              setSize(size + 1)
+            }}
+          >
+            {t('list.load_more')}
+          </HDSButton>
+        </div>
+      )}
+    </Container>
+  </div>
+  )
+
+}

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -83,8 +83,11 @@
   color: var(--color-white);
   margin-right: var(--spacing-xs);
   margin-bottom: var(--spacing-s);
-  text-transform: capitalize;
   width: auto;
+
+  span:first-letter {
+    text-transform: capitalize;
+  }
 }
 
 .supplementary {

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -22,8 +22,8 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
   return data
 }
 
-export const getEventsSearch = async (eventsIndex: number) => {
-  const { data } = await axios(`${EVENTS_SEARCH_URL}`, { params: { index: eventsIndex } })
+export const getEventsSearch = async (eventsIndex: number, filter: string | null) => {
+  const { data } = await axios(`${EVENTS_SEARCH_URL}`, { params: { index: eventsIndex, filter: filter } })
   return data
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,20 @@ export interface EventState {
   total: number
   events: EventData[]
 }
+
+export interface EventListProps {
+  pageType?: string
+  field_title: string
+  field_events_list_short: boolean
+  field_event_tag_filter: string[]
+  field_background_color: {
+    field_css_name: string
+  } | null
+  field_events_list_desc:  DrupalFormattedText
+  locationId: string | null
+  field_street_address: string
+}
+
 declare global {
   interface Window {
     _paq: any


### PR DESCRIPTION
Fixes the following issues
- Selecting new filter, result was random amount events instead of configured 9.
- Load More button didn't give 9 more. Still an issue in random cases. Works now more reliable.
- Load More button click sometimes caused application error and crashed.
- Filters changed by the filtered events tags. Not all filters were displayed.

Relates to THF-404, THF-405 &  THF-411