### PR TITLE
THF-406: Fixing app crash when navigating to cookies page.

### DIFF
--- a/src/components/consentInfo/ConsentInfo.tsx
+++ b/src/components/consentInfo/ConsentInfo.tsx
@@ -1,6 +1,5 @@
 import { Button, IconAlertCircleFill } from 'hds-react'
 import { useTranslation } from 'next-i18next'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import styles from './consentInfo.module.scss'
 
@@ -12,10 +11,7 @@ export default function ConsentInfo(): JSX.Element {
     <div className={styles.consentInfoWrapper}>
       <h3><IconAlertCircleFill /> {t('consent_info.title')}</h3>
       <p>{t('consent_info.text')}</p>
-
-      <Link href={locale === 'fi' ? '/cookies' : `${locale}/cookies`} passHref>
-        <Button variant="secondary">{t('consent_info.button')}</Button>
-      </Link>
+      <a href={locale === 'fi' ? '/cookies' : `${locale}/cookies`}><Button variant="secondary">{t('consent_info.button')}</Button></a>
     </div>
   )
 }


### PR DESCRIPTION
- Fixes an error of "Target container is not a DOM element." when navigating to cookies page from consents info banner link 