### PR TITLE
Thf 446 published date for articles UI

### DIFF
--- a/src/components/pageTemplates/NodeArticlePage.tsx
+++ b/src/components/pageTemplates/NodeArticlePage.tsx
@@ -20,9 +20,9 @@ export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.E
             <div className='lead-in'>{field_lead}</div>
           )}
           <div className={styles.pageDivider}></div>
-          {published_at === null ?
-            <p className={styles.articleDate}><time dateTime={created}>{`${dateformat(created, 'dd.mm.yyyy')}`}</time></p> :
-            <p className={styles.articleDate}><time dateTime={published_at}>{`${dateformat(published_at, 'dd.mm.yyyy')}`}</time></p>
+          {published_at !== null ?
+            <p className={styles.articleDate}><time dateTime={published_at}>{`${dateformat(published_at, 'dd.mm.yyyy')}`}</time></p>:
+            <p className={styles.articleDate}><time dateTime={created}>{`${dateformat(created, 'dd.mm.yyyy')}`}</time></p>
           }
           {field_content?.length > 0 && (
             <ContentMapper content={node.field_content} langcode={langcode} />

--- a/src/components/pageTemplates/NodeArticlePage.tsx
+++ b/src/components/pageTemplates/NodeArticlePage.tsx
@@ -10,7 +10,9 @@ interface NodeArticlePageProps {
 }
 
 export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.Element {
-  const { title, field_lead, created, field_content, langcode, published_at } = node
+  const { title, field_lead, created, field_content, langcode, published_at } = node;
+  const articleDate = published_at !== null ? published_at : created;
+
   return (
     <article>
       <Container className="container content-region">
@@ -20,10 +22,7 @@ export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.E
             <div className='lead-in'>{field_lead}</div>
           )}
           <div className={styles.pageDivider}></div>
-          {published_at !== null ?
-            <p className={styles.articleDate}><time dateTime={published_at}>{`${dateformat(published_at, 'dd.mm.yyyy')}`}</time></p>:
-            <p className={styles.articleDate}><time dateTime={created}>{`${dateformat(created, 'dd.mm.yyyy')}`}</time></p>
-          }
+          { articleDate && <p className={styles.articleDate}><time dateTime={articleDate}>{`${dateformat(articleDate, 'dd.mm.yyyy')}`}</time></p>}
           {field_content?.length > 0 && (
             <ContentMapper content={node.field_content} langcode={langcode} />
           )}

--- a/src/components/pageTemplates/NodeArticlePage.tsx
+++ b/src/components/pageTemplates/NodeArticlePage.tsx
@@ -10,7 +10,7 @@ interface NodeArticlePageProps {
 }
 
 export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.Element {
-  const { title, field_lead, created, field_content, langcode} = node
+  const { title, field_lead, created, field_content, langcode, published_at } = node
   return (
     <article>
       <Container className="container content-region">
@@ -20,9 +20,10 @@ export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.E
             <div className='lead-in'>{field_lead}</div>
           )}
           <div className={styles.pageDivider}></div>
-          {created && (
-            <p className={styles.articleDate}><time dateTime={created}>{`${dateformat(created, 'dd.mm.yyyy')}`}</time></p>
-          )}
+          {published_at === null ?
+            <p className={styles.articleDate}><time dateTime={created}>{`${dateformat(created, 'dd.mm.yyyy')}`}</time></p> :
+            <p className={styles.articleDate}><time dateTime={published_at}>{`${dateformat(published_at, 'dd.mm.yyyy')}`}</time></p>
+          }
           {field_content?.length > 0 && (
             <ContentMapper content={node.field_content} langcode={langcode} />
           )}

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -183,7 +183,8 @@ export const baseArticlePageQueryParams = () =>
       'langcode',
       'field_lead',
       'field_content',
-      'status'
+      'status',
+      'published_at',
     ])
     .addFields(CONTENT_TYPES.TEXT, [
       'field_text'


### PR DESCRIPTION
Publication date field added to article content type.

How to test:
- Related PR -> [THF-446-published-date-for-articles-drupal](https://github.com/City-of-Helsinki/drupal-employment-services/pull/123)
- Run drupal site branch with introductions  `THF-446-published-date-for-articles-drupal` 
- Create new article page on Drupal https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add
- Check that article has date under page title.
- Create new article https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add and scheduled publication date for next day.
- See next day that the date underneath title has changed to the publication date.

Developer:
Add console.log('node') NodeArticlePage.tsx file row 13 and open the created article page. You should see published_at field in the console.  
