### PR TITLE
Give margin to hero left

### DIFF
--- a/src/components/hero/hero.module.scss
+++ b/src/components/hero/hero.module.scss
@@ -41,6 +41,7 @@
   position: relative;
   > span {
     left: 0.5px !important;
+    top: 0.5px !important;
   }
 }
 

--- a/src/components/hero/hero.module.scss
+++ b/src/components/hero/hero.module.scss
@@ -39,6 +39,9 @@
   height: 480px;
   margin-top: -70px;
   position: relative;
+  > span {
+    left: 0.5px !important;
+  }
 }
 
 .heroMobileKoros {
@@ -53,7 +56,7 @@
   .heroContainer {
     height: 480px;
   }
-  
+
   .heroTextContainer {
     display: flex;
     min-height: 480px;


### PR DESCRIPTION
Hero's left edge of the picture came to the surface if picture was zoomed or from a big screen. Given marging-left to span surrounding the img element. Had to use !important to override the element style attribute.

how to test:

- Verify the problems by going to [tyollisyyspalvelut](https://tyollisyyspalvelut.hel.fi/) and zoom the hero element picture. 
- then do the same in the UI with this branch. You shouldn’t  see the lines any more. 