### PR TITLE
Thf 416 location extra info

### DIFF
--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { useTranslation } from 'next-i18next'
 import { Container } from 'hds-react'
-import { IconLocation, IconLinkExternal } from 'hds-react'
+import { IconLocation, IconLinkExternal, IconAlertCircle } from 'hds-react'
 
 import { Node } from '@/lib/types'
 import HtmlBlock from '@/components/HtmlBlock'
@@ -17,8 +17,8 @@ interface NodeEventPageProps {
   node: Node
 }
 
-function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element { 
-  const { title, field_text, field_location, field_location_id, field_start_time, field_end_time, field_tags, field_image_url, field_image_alt, field_info_url, field_external_links, field_street_address, field_event_status } = node
+function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
+  const { title, field_text, field_location, field_location_id, field_start_time, field_end_time, field_tags, field_image_url, field_image_alt, field_info_url, field_external_links, field_street_address, field_event_status, field_location_extra_info } = node
   const { t } = useTranslation('common')
   const { locale } = useRouter()
   const infoUrlText = field_info_url && field_info_url.startsWith('https://teams.microsoft') ? t('event.info_url_text_teams') : t('event.info_url_text')
@@ -46,27 +46,37 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                     <IconLocation />
                   </div>
                   <div>
-                    { field_street_address 
+                    { field_street_address
                       ? <a href={`https://palvelukartta.hel.fi/${locale}/unit/${field_location_id}`} target="_blank" rel="noreferrer">{field_location}{field_street_address ? `, ${field_street_address}` : ''}<IconLinkExternal size="s" aria-hidden="true"/></a>
                       : field_location
                     }
-                  </div> 
+                  </div>
                 </div>
+                { field_location_extra_info &&
+                  <div className={styles.location}>
+                    <div>
+                      <IconAlertCircle size="s" aria-hidden="true" />
+                    </div>
+                    <div>
+                      {field_location_extra_info}
+                    </div>
+                  </div>
+                }
               </div>
             </div>
             <div className={`${styles.contentContainer} content-region`}>
-              {field_text?.processed && 
+              {field_text?.processed &&
               <HtmlBlock field_text={field_text} />
               }
 
-              {field_info_url && 
+              {field_info_url &&
                 <Link
                   href={field_info_url}
                   text={infoUrlText}
                 />
               }
 
-              { field_external_links.length > 0 && 
+              { field_external_links.length > 0 &&
                 field_external_links.map((externalLink: any, key: any) => (
                   <Link
                     key={key}

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -161,7 +161,8 @@ export const baseEventQueryParams = () =>
       'field_external_links',
       'field_info_url',
       'field_short_description',
-      'field_street_address'
+      'field_street_address',
+      'field_location_extra_info'
     ])
 
 const getEventPageQueryParams = () =>
@@ -232,7 +233,7 @@ export const baseTprUnitQueryParams = () =>
       'picture_url_override',
       'picture_url',
       'drupal_internal__id'
-    ])    
+    ])
     .addFields(CONTENT_TYPES.ACCORDION, [
       'field_accordion_type',
       'field_accordion_title_level',
@@ -243,7 +244,7 @@ export const baseTprUnitQueryParams = () =>
     .addFields(CONTENT_TYPES.ACCORDION_ITEM, [
       'field_accordion_item_content',
       'field_accordion_item_heading'
-    ])    
+    ])
     .addFields(CONTENT_TYPES.LIST_OF_LINKS, [
       'field_list_of_links_design',
       'field_list_of_links_links',


### PR DESCRIPTION
Added location extra info to the event pages.

**how to test:**

- Go to page (or if you find some other page with field_location_extra_info) http://localhost:3000/ajankohtaista/tapahtumat/sol-rekrytoi-logistiikka-alalle
-  you should see under location extra info with exclamation mark icon.
- Take some other page event page example http://localhost:3000/ajankohtaista/tapahtumat/tyoelamavalmennusta-itakeskuksessa-40 and you should see the location extra info and icon there.