### PR TITLE
Thf 455 cookies sv en url

### DIFF
--- a/src/components/consentInfo/ConsentInfo.tsx
+++ b/src/components/consentInfo/ConsentInfo.tsx
@@ -11,7 +11,7 @@ export default function ConsentInfo(): JSX.Element {
     <div className={styles.consentInfoWrapper}>
       <h3><IconAlertCircleFill /> {t('consent_info.title')}</h3>
       <p>{t('consent_info.text')}</p>
-      <a href={locale === 'fi' ? '/cookies' : `${locale}/cookies`}><Button>{t('consent_info.button')}</Button></a>
+      <a href={locale === 'fi' ? '/cookies' : `/${locale}/cookies`}><Button>{t('consent_info.button')}</Button></a>
     </div>
   )
 }


### PR DESCRIPTION
Cookie sv and en link not working on react and share component. The link adding en/cookies or sv/cookies end of the link. Please see the picture below. The link should be http://localhost:3000/en/cookies.

<img width="769" alt="Screenshot 2023-03-09 at 10 17 50" src="https://user-images.githubusercontent.com/42113018/223961784-c02059b8-3c35-4d57-9303-70f26678f5eb.png">

How to test:
- Take the branch and repeat the steps and you should end up to the cookie page
- Open page and accept only essential cookies 
- Cookies can be change on page http://localhost:3000/cookies
- Go to example page en page http://localhost:3000/en/official-matters/welcome-client
- Note!! Page needs to be something else than http://localhost:3000
- Scroll  down to the react and share component (image  below)
- Click the button 
- You should get the cookies page
- Try also with sv page 