### PR TITLE
THF-463: Added status to news list and filter by the status

### DIFF
--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useState } from 'react'
-import useSWR from 'swr'
 import { useTranslation } from 'next-i18next'
 import { Button as HDSButton, IconPlus, IconArrowRight, Container } from 'hds-react'
-
 import dateformat from 'dateformat'
+import useSWR from 'swr'
 
 import { DrupalFormattedText, Node } from '@/lib/types'
 import { getPathAlias } from '@/lib/helpers'
 import { getNews } from '@/lib/client-api'
-
 import HtmlBlock from '@/components/HtmlBlock'
-
 import styles from './news.module.scss'
 
 interface NewsListProps {
@@ -18,6 +15,18 @@ interface NewsListProps {
   field_short_list: boolean
   field_news_list_desc: DrupalFormattedText
   langcode: string
+}
+interface News {
+  created: string,
+  path: Path,
+  title: string,
+  status: boolean,
+}
+
+interface Path {
+  alias: string,
+  langcode: string,
+  pid: number,
 }
 
 function NewsList(props: NewsListProps): JSX.Element {
@@ -31,11 +40,12 @@ function NewsList(props: NewsListProps): JSX.Element {
     fetcher
   )
   const total: number = news && news.length || 0
-
   useEffect(() => {
     const filterNews = () => {
-      const pn = news && news.slice(0, 4*newsIndex)
-      setPaginatedNews(pn)
+      const paginatedArticle = news && news
+      .filter((newsArticle: News) => newsArticle.status !== false )
+      .slice(0, 4*newsIndex)
+      setPaginatedNews(paginatedArticle)
     }
     filterNews()
   }, [news, newsIndex]) // eslint-disable-line
@@ -59,7 +69,7 @@ function NewsList(props: NewsListProps): JSX.Element {
           </div>
         }
         <div className={`${styles.newsList} ${field_short_list && styles.short}`}>
-          { paginatedNews && paginatedNews.map((news: any, key: any) => (
+          { paginatedNews && paginatedNews.map((news: News, key: number) => (
             <div className={styles.newsCard} key={key}>
                 <a href={getPathAlias(news.path)}>
                   <h3 className={styles.newsTitle}>{news.title}</h3>

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -181,7 +181,8 @@ export const baseArticlePageQueryParams = () =>
       'revision_timestamp',
       'langcode',
       'field_lead',
-      'field_content'
+      'field_content',
+      'status'
     ])
     .addFields(CONTENT_TYPES.TEXT, [
       'field_text'


### PR DESCRIPTION
Bring only published news to the news page.

How to test:
- Create new article at least one published and one unpublished. https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add/article
- The news list should now show only published articles http://localhost:3000/ajankohtaista/uutiset