### PR TITLE
Thf 470  linked event tags UI

### DIFF
--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -12,7 +12,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   const elastic = Elastic.getElasticClient()
 
-  let response: any = {}
   const body: any = {
     "query": {
       "match_all": {}
@@ -21,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     "aggs": {
       "events_tags": {
         "terms": {
-          "field": "field_tags.keyword",
+          "field": "field_tags",
           "size": 100
         }
       }
@@ -35,6 +34,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     })
 
     const { events_tags }: any = searchRes.aggregations
+
 
     res.json(events_tags?.buckets)
 


### PR DESCRIPTION
Drupal tags didn't bring the filtering to the UI. The tag were fetch from wrong field.

Note that when languages are added to tags this may need fixing.

How to test:
- Run this branch with Drupal branch https://github.com/City-of-Helsinki/drupal-employment-services/pull/128
- See that you can see the filtering tags on even page and use them for filtering. http://localhost:3000/ajankohtaista/tapahtumat
- 
<img width="1230" alt="Screenshot 2023-03-13 at 13 36 49" src="https://user-images.githubusercontent.com/42113018/224691094-0f269927-79c9-4d54-8ea8-fc90be55c7a6.png">

