### PR TITLE
THF-470: restore keyword value

### DIFF
--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     "aggs": {
       "events_tags": {
         "terms": {
-          "field": "field_tags",
+          "field": "field_tags.keyword",
           "size": 100
         }
       }


### PR DESCRIPTION
Restore keyword value. The error what was fixed was only in local environment.

How to test:

- if the branch not working on you local environment 
- On your Drupal project run commands below
- run to clear electric search `curl -X DELETE http://localhost:9200/events_\*`
- `make shell`
-  run reindexing `drush search-api-reindex`
- run indexing `drush search-api:index`
- check your http://localhost:3000/ajankohtaista/tapahtumat
- you should now see the filtering tag above the events.