### PR TITLE
THF-459: Add cookie domain setting to modal and cookies page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,8 @@ const publicRuntimeConfig = {
   MATOMO_URL: process.env.MATOMO_URL,
   REACT_AND_SHARE_FI: process.env.REACT_AND_SHARE_FI,
   REACT_AND_SHARE_SV: process.env.REACT_AND_SHARE_SV,
-  REACT_AND_SHARE_EN: process.env. REACT_AND_SHARE_EN
+  REACT_AND_SHARE_EN: process.env.REACT_AND_SHARE_EN,
+  COOKIE_DOMAIN: process.env.COOKIE_DOMAIN
 }
 
 const serverRuntimeConfig = {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,10 +2,12 @@ import '../styles/globals.scss'
 import { appWithTranslation } from 'next-i18next'
 import type { AppProps } from 'next/app'
 import { CookieModal } from 'hds-react';
+import getConfig from 'next/config'
 import { useConsentStatus, useCookieConsents, useMatomo } from '@/hooks/useAnalytics';
 import { useEffect, useState } from 'react';
 
 export const MyApp = ({ Component, pageProps }: AppProps) => {
+  const { COOKIE_DOMAIN } = getConfig().publicRuntimeConfig
   const [ cookieModal, setCookieModal ] = useState<boolean>(true)
   
   useEffect(() => {
@@ -20,7 +22,7 @@ export const MyApp = ({ Component, pageProps }: AppProps) => {
 
   return (
     <>
-      { cookieModal && <CookieModal contentSource={contentSource} /> }
+      { cookieModal && <CookieModal cookieDomain={COOKIE_DOMAIN} contentSource={contentSource} /> }
       <Component {...pageProps} />
     </>
   );

--- a/pages/cookies.tsx
+++ b/pages/cookies.tsx
@@ -19,7 +19,7 @@ interface CookiePageProps {
 
 export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<CookiePageProps>> {
   const { locale, defaultLocale } = context as { locale: Locale, defaultLocale: Locale }
-  const { REVALIDATE_TIME } = getConfig().serverRuntimeConfig  
+  const { REVALIDATE_TIME } = getConfig().serverRuntimeConfig 
   const langLinks = { fi: '/cookies', en: '/en/cookies', sv: '/sv/cookies'}
   const { tree: menu } = await getMenu('main', locale, defaultLocale)
   const { tree: themes } = await getMenu('additional-languages', locale, defaultLocale)
@@ -46,6 +46,7 @@ export async function getStaticProps(context: GetStaticPropsContext): Promise<Ge
 export default function Cookies({ nav, footer }: CookiePageProps) {
   const { t } = useTranslation('common')
   const contentSource = useCookieConsents()
+  const { COOKIE_DOMAIN } = getConfig().publicRuntimeConfig
 
   return (
     <Layout header={nav} footer={footer}>
@@ -53,7 +54,7 @@ export default function Cookies({ nav, footer }: CookiePageProps) {
         <title>{t('site_title')}</title>
       </Head>
       <Container className="container">
-        <CookiePage contentSource={contentSource} />
+        <CookiePage cookieDomain={COOKIE_DOMAIN} contentSource={contentSource} />
       </Container>
     </Layout>
   )

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -50,7 +50,6 @@ export const useCookieConsents = (): any => {
       onLanguageChange,
     },
     focusTargetSelector: '#focused-element-after-cookie-consent-closed',
-    CookieDomain: 'tyollisyyspalvelut.hel.fi',
     optionalCookies: {
       groups: [
         {


### PR DESCRIPTION
This PR adds the cookie domain from env variables to the modal and cookie information page. Should fix the issue with the domain being set to `.hel.fi` or `.hel.ninja`.

**To test**
- Checkout branch
- Add this line to to your `.env.local` file: `COOKIE_DOMAIN=localhost` and run `yarn dev`
- Open this page: http://localhost:3000/cookies (this is easier to test in a private browsing window)
- Accept all cookies from the popup. This should reload the page, after which all the cookies should be accepted on the page too.
- Go to http://localhost:3000/tyonhaku and scroll down. The React & Share banner should be visible
- Delete all cookies and reload the page. The cookie popup should appear again and the React & Share banner should show a disclaimer about cookies not being accepted
- Go to the cookies information page and accept all cookies from the form on the page (not the popup). This should work the same as previously
- Edit your `.env.local` file and change the `COOKIE_DOMAIN` value to `tyollisyyspalvelut.hel.ninja`. Run `yarn dev`
- Delete all cookies and reload the front page and try to accept the cookies. You should get this warning in your console: `Cookie “city-of-helsinki-cookie-consents” has been rejected for invalid domain.` (This is just to make sure the value is coming from the env variables)
- Change the `COOKIE_DOMAIN` value back to `localhost` to prevent any further issues