### PR TITLE
THF-416. Add sing up button to the event pages

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,7 +50,8 @@
     "remote_event": "Remote event",
     "info_url_text": "Event homepage",
     "info_url_text_teams": "Open Teams-event",
-    "cancelled_text": "Cancelled"
+    "cancelled_text": "Cancelled",
+    "field_offers_info_url": "Sign up"
   },
   "video": {
     "cookie_consent": "You have not allowed the use of cookies on this site.",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -50,7 +50,8 @@
     "remote_event": "Etätapahtuma",
     "info_url_text": "Tapahtuman kotisivut",
     "info_url_text_teams": "Avaa Teams-tapahtuma",
-    "cancelled_text": "Peruttu"
+    "cancelled_text": "Peruttu",
+    "field_offers_info_url": "Ilmoittaudu"
   },
   "video": {
     "cookie_consent": "Et ole antanut lupaa asettaa evästeitä.",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -50,7 +50,8 @@
     "remote_event": "Distansevenemang",
     "info_url_text": "Evenemangets hemsida",
     "info_url_text_teams": "Öppna Teams-evenemanget",
-    "cancelled_text": "Inställt"
+    "cancelled_text": "Inställt",
+    "field_offers_info_url": "Bli Medlem"
   },
   "video": {
     "cookie_consent": "Du har inte gett tillstånd att installera cookies.",

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -1,16 +1,15 @@
 import Image from 'next/image'
 import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
 import { Container } from 'hds-react'
-import { IconLocation, IconLinkExternal, IconAlertCircle } from 'hds-react'
+import { IconLocation, IconLinkExternal, IconAlertCircle, Button } from 'hds-react'
 
 import { Node } from '@/lib/types'
 import HtmlBlock from '@/components/HtmlBlock'
 import TagList from '@/components/events/TagList'
 import DateTime from '@/components/events/DateTime'
 import Link from '@/components/link/Link'
-
 import styles from './eventPage.module.scss'
-import { useRouter } from 'next/router'
 import EventStatus from '../events/EventStatus'
 
 interface NodeEventPageProps {
@@ -18,10 +17,14 @@ interface NodeEventPageProps {
 }
 
 function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
-  const { title, field_text, field_location, field_location_id, field_start_time, field_end_time, field_tags, field_image_url, field_image_alt, field_info_url, field_external_links, field_street_address, field_event_status, field_location_extra_info } = node
+  const { title, field_text, field_location, field_location_id, field_start_time, field_end_time, field_tags, field_image_url, field_image_alt, field_info_url, field_external_links, field_street_address, field_event_status, field_location_extra_info, field_offers_info_url  } = node
   const { t } = useTranslation('common')
   const { locale } = useRouter()
   const infoUrlText = field_info_url && field_info_url.startsWith('https://teams.microsoft') ? t('event.info_url_text_teams') : t('event.info_url_text')
+
+  const onClick = () => {
+    location.href = field_offers_info_url;
+  }
 
   return (
     <article>
@@ -86,7 +89,11 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                 ))
               }
             </div>
-
+            {field_offers_info_url &&
+              <Button onClick={onClick} theme="black" iconRight={<IconLinkExternal size="m" aria-hidden="true" />}>
+                { t('event.field_offers_info_url') }
+              </Button>
+            }
           </div>
         </div>
       </Container>

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -162,7 +162,8 @@ export const baseEventQueryParams = () =>
       'field_info_url',
       'field_short_description',
       'field_street_address',
-      'field_location_extra_info'
+      'field_location_extra_info',
+      'field_offers_info_url'
     ])
 
 const getEventPageQueryParams = () =>


### PR DESCRIPTION
Created new sing up button to the event page. Button is only shown if the linked event has sing up url.

How to test:
- This branch need to be tested with branch https://github.com/City-of-Helsinki/drupal-employment-services/pull/129
- follow the how to test instructions from branch below
- go to page http://localhost:3000/ajankohtaista/tapahtumat/testitapahtuma
- you should see the new sing up button end of the page.
- go to event and you should not see the button https://tyollisyyspalvelut-ui.test.hel.ninja/ajankohtaista/tapahtumat/helsinki-info-neuvoo-itakeskuksessa-9