### PR TITLE
THF-329: Change office list order by menu

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -1,7 +1,7 @@
 import { Container } from 'hds-react'
+import { DrupalMenuLinkContent } from 'next-drupal'
 
 import HtmlBlock from '@/components/HtmlBlock'
-import { CONTENT_TYPES } from '@/lib/drupalApiTypes'
 import ListOfLinks from '@/components/listOfLinks/ListOfLinks'
 import Accordion from '@/components/accordion/Accordion'
 import Banner from '@/components/banner/Banner'
@@ -12,22 +12,24 @@ import NewsList from '@/components/news/NewsList'
 import ParagraphImage from '@/components/paragraphImage/ParagraphImage'
 import Quote from '@/components/quote/Quote'
 import SujoEmbedded from '@/components/sujoEmbedded/sujoEmbedded'
+import Events from '@/components/events/Events'
+import { CONTENT_TYPES } from '@/lib/drupalApiTypes'
+import { NavProps } from '@/lib/types'
 import UnitsList from './tprUnits/UnitsList'
 import MapEmbedded from './mapEmbedded/MapEmbedded'
-import Events from '@/components/events/Events'
+
 
 
 interface ContentMapperProps {
   content: any,
-  pageType?: string
-  mapId?: number | null
-  locationId?: string | null
-  langcode?: string
+  pageType?: string,
+  mapId?: number | null,
+  locationId?: string | null,
+  langcode?: string,
+  sidebar?: NavProps,
 }
 
-export function ContentMapper({ content, pageType, locationId, mapId, langcode, ...props }: ContentMapperProps): JSX.Element {
- // console.log('content: ', content)
-
+export function ContentMapper({ content, pageType, locationId, mapId, langcode, sidebar, ...props }: ContentMapperProps): JSX.Element {
   return content.map((item: any) => {
     const { type, id } = item
     const key = `paragraph--${type}-${id}`
@@ -129,7 +131,7 @@ export function ContentMapper({ content, pageType, locationId, mapId, langcode, 
         if (!item?.id) {
           return null
         }
-        return <UnitsList key={key} />
+        return <UnitsList {...sidebar} key={key}/>
 
       default:
         console.log('unmapped type: ', type)

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -12,7 +12,7 @@ import styles from './navigation.module.scss'
 export function Sidebar(sidebar:NavProps): JSX.Element {
   const { locale, menu, langLinks } = sidebar;
   const { t } = useTranslation('common');
-  const activePath = langLinks[locale ? locale: 'fi']
+  const activePath = langLinks[locale ? locale : 'fi']
 
   const getSideNav = (menuArray: DrupalMenuLinkContent[]|undefined):{ nav: ReactElement[], defaultOpenMainLevels: number[] } => {
     const nav: ReactElement[] = []

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -10,12 +10,11 @@ import styles from './navigation.module.scss'
 
 
 export function Sidebar(sidebar:NavProps): JSX.Element {
-  const { locale, menu, langLinks } = sidebar
-  const { t } = useTranslation('common')
+  const { locale, menu, langLinks } = sidebar;
+  const { t } = useTranslation('common');
+  const activePath = langLinks[locale ? locale: 'fi']
 
-  const activePath = langLinks[locale]
-
-  const getSideNavi = (menuArray: DrupalMenuLinkContent[]|undefined):{ nav: ReactElement[], defaultOpenMainLevels: number[] } => {
+  const getSideNav = (menuArray: DrupalMenuLinkContent[]|undefined):{ nav: ReactElement[], defaultOpenMainLevels: number[] } => {
     const nav: ReactElement[] = []
     let defaultOpenMainLevels: number[] = []
 
@@ -96,7 +95,7 @@ export function Sidebar(sidebar:NavProps): JSX.Element {
     return {nav, defaultOpenMainLevels}
   }
 
-  const { nav, defaultOpenMainLevels } = getSideNavi(menu)
+  const { nav, defaultOpenMainLevels } = getSideNav(menu)
 
   return (
     <SideNavigation

--- a/src/components/pageTemplates/NodeBasicPage.tsx
+++ b/src/components/pageTemplates/NodeBasicPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Container } from 'hds-react'
 import { NavProps, Node } from '@/lib/types'
 import ContentMapper from '@/components/ContentMapper'
@@ -9,8 +10,15 @@ interface NodeBasicPageProps {
 }
 
 function NodeBasicPage({ node, sidebar, ...props }: NodeBasicPageProps): JSX.Element {
-  // console.log({node})
-  const { title, field_lead_in, field_content, field_notification, field_hide_sidebar, field_lower_content, langcode } = node
+  const {
+    title,
+    field_lead_in,
+    field_content,
+    field_notification,
+    field_hide_sidebar,
+    field_lower_content,
+    langcode,
+  } = node;
 
   return (
     <article>
@@ -18,7 +26,7 @@ function NodeBasicPage({ node, sidebar, ...props }: NodeBasicPageProps): JSX.Ele
         <div className="columns">
           <div className={`content-region col col-8${!field_hide_sidebar ? " flex-grow" : "" }`}>
             {field_notification?.length > 0 && (
-              <ContentMapper content={node.field_notification}/>
+              <ContentMapper content={node.field_notification} />
             )}
             <h1>{title}</h1>
             {field_lead_in && (
@@ -37,7 +45,7 @@ function NodeBasicPage({ node, sidebar, ...props }: NodeBasicPageProps): JSX.Ele
         <div className="columns">
           <div className="lower-content-region col col-12">
             {field_lower_content?.length > 0 && (
-              <ContentMapper content={node.field_lower_content} pageType='basic' langcode={langcode} />
+              <ContentMapper content={node.field_lower_content} pageType='basic' langcode={langcode} sidebar={sidebar} />
             )}
           </div>
         </div>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -203,3 +203,9 @@ export const getDefaultImage = (node: Node): string => {
 
   return process.env.NEXT_PUBLIC_SITE_URL + "/tyollisyyspalvelut.png"
 }
+
+export const sortArrayByOtherArray = (array: any[], sortArray: string[]) => {
+  return [...array].sort(
+    (a , b) => sortArray.indexOf(a.name_override) - sortArray.indexOf(b.name_override)
+  )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,7 +35,7 @@ export interface DrupalFormattedText {
 }
 
 export interface NavProps {
-  locale: Locale
+  locale?: Locale
   menu?: DrupalMenuLinkContent[]
   themes?: DrupalMenuLinkContent[]
   langLinks?: any
@@ -113,7 +113,7 @@ export interface EventListProps {
 export interface SearchState {
   total: number
   results: SearchData[]
-} 
+}
 
 export interface SearchData {
   entity_type: string


### PR DESCRIPTION
TPR units were wanted to be same order as they are on side navigation.  First we loop the menu object and get the array from it. We then sort the units by the order of the array from the menu object.

How to test:
- Check out this branch.
- go to http://localhost:3000/yhteystiedot/toimipisteet
- check that the offices in same order as they are in menu. 
- You need to check all languages.
- Then go to main menu edit and change order of the offices.
- https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/structure/menu/manage/main
- check again that the order is same as it is on navigation.
- You need to check all languages.
- Add you own menu item under office.
- check that the new item don’t mix the order.
- You need to check all languages.