### PR TITLE
Thf 446 published date for articles UI

### DIFF
--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -17,7 +17,7 @@ interface NewsListProps {
   langcode: string
 }
 interface News {
-  created: string,
+  published_at?: string,
   path: Path,
   title: string,
   status: boolean,
@@ -74,7 +74,7 @@ function NewsList(props: NewsListProps): JSX.Element {
                 <a href={getPathAlias(news.path)}>
                   <h3 className={styles.newsTitle}>{news.title}</h3>
                 </a>
-              <p className={styles.articleDate}><time dateTime={news.created}>{`${dateformat(news.created, 'dd.mm.yyyy')}`}</time></p>
+              {news.published_at && <p className={styles.articleDate}><time dateTime={news.published_at}>{`${dateformat(news.published_at, 'dd.mm.yyyy')}`}</time></p>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Changed created date in news listing to published date.

How to test:
- Create new article https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add/article
- Save the article with out publishing it and schedule a publication date for tomorrow 
- The should be in the list next day with scheduled publication date.
- Also all news should still have a date.