### PR TITLE
Thf 454 news short list

### DIFF
--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -49,11 +49,7 @@ function NewsList({
   const total: number = (news && news.length) || 0
   useEffect(() => {
     const filterNews = () => {
-      const paginatedArticle =
-        news &&
-        news
-          .filter((newsArticle: News) => newsArticle.status !== false)
-          .slice(0, 4 * newsIndex)
+      const paginatedArticle = news && news.slice(0, 4 * newsIndex)
       setPaginatedNews(paginatedArticle)
     }
     filterNews()
@@ -61,7 +57,9 @@ function NewsList({
 
   const loadMoreText = t('list.load_more')
   return (
-    <div className='component' style={{ backgroundColor: `var(--color-${bgColor})` }}>
+    <div
+      className='component'
+      style={{ backgroundColor: `var(--color-${bgColor})` }}>
       <Container className='container'>
         <div className={styles.newsListTitleArea}>
           {field_title && <h2>{field_title}</h2>}
@@ -96,7 +94,7 @@ function NewsList({
             ))}
         </div>
 
-        {!field_short_list  && paginatedNews && total > paginatedNews.length && (
+        {!field_short_list && paginatedNews && total > paginatedNews.length && (
           <div className={styles.loadMore}>
             <HDSButton
               variant='supplementary'
@@ -109,7 +107,6 @@ function NewsList({
             </HDSButton>
           </div>
         )}
-
       </Container>
     </div>
   )

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -11,11 +11,14 @@ import HtmlBlock from '@/components/HtmlBlock'
 import styles from './news.module.scss'
 
 interface NewsListProps {
-  field_title: string
-  field_short_list: boolean
-  field_news_list_desc: DrupalFormattedText
-  langcode: string
-}
+  field_title: string;
+  field_short_list: boolean;
+  field_news_list_desc: DrupalFormattedText;
+  langcode: string;
+  field_background_color: {
+    field_css_name: string;
+  }
+};
 interface News {
   published_at?: string,
   path: Path,
@@ -29,56 +32,71 @@ interface Path {
   pid: number,
 }
 
-function NewsList(props: NewsListProps): JSX.Element {
-  const { field_title, field_short_list, field_news_list_desc, langcode } = props
+function NewsList({
+  field_title,
+  field_short_list,
+  field_news_list_desc,
+  langcode,
+  field_background_color,
+}: NewsListProps): JSX.Element {
   const { t } = useTranslation()
   const [newsIndex, setNewsIndex] = useState<number>(1)
   const [paginatedNews, setPaginatedNews] = useState<Node[]>([])
+  const bgColor = field_background_color?.field_css_name || 'white'
   const fetcher = () => getNews(field_short_list, langcode)
-  const { data: news, error } = useSWR(
-    `/news`,
-    fetcher
-  )
-  const total: number = news && news.length || 0
+  const { data: news, error } = useSWR(`/news`, fetcher)
+
+  const total: number = (news && news.length) || 0
   useEffect(() => {
     const filterNews = () => {
-      const paginatedArticle = news && news
-      .filter((newsArticle: News) => newsArticle.status !== false )
-      .slice(0, 4*newsIndex)
+      const paginatedArticle =
+        news &&
+        news
+          .filter((newsArticle: News) => newsArticle.status !== false)
+          .slice(0, 4 * newsIndex)
       setPaginatedNews(paginatedArticle)
     }
     filterNews()
   }, [news, newsIndex]) // eslint-disable-line
 
   const loadMoreText = t('list.load_more')
-
   return (
-    <div className='component'>
+    <div className='component' style={{ backgroundColor: `var(--color-${bgColor})` }}>
       <Container className='container'>
         <div className={styles.newsListTitleArea}>
-          {field_title &&
-            <h2>{field_title}</h2>
-          }
-          {field_short_list &&
-            <a href={t('list.news_url')}>{t('list.show_all_news')} <IconArrowRight size="l" /></a>
-          }
+          {field_title && <h2>{field_title}</h2>}
+          {field_short_list && (
+            <a href={t('list.news_url')}>
+              {t('list.show_all_news')} <IconArrowRight size='l' />
+            </a>
+          )}
         </div>
-        {field_news_list_desc?.processed &&
+        {field_news_list_desc?.processed && (
           <div className={styles.newsListDescription}>
             <HtmlBlock field_text={field_news_list_desc} />
           </div>
-        }
-        <div className={`${styles.newsList} ${field_short_list && styles.short}`}>
-          { paginatedNews && paginatedNews.map((news: News, key: number) => (
-            <div className={styles.newsCard} key={key}>
+        )}
+        <div
+          className={`${styles.newsList} ${field_short_list && styles.short}`}>
+          {paginatedNews &&
+            paginatedNews.map((news: News, key: number) => (
+              <div className={styles.newsCard} key={key}>
                 <a href={getPathAlias(news.path)}>
                   <h3 className={styles.newsTitle}>{news.title}</h3>
                 </a>
-              {news.published_at && <p className={styles.articleDate}><time dateTime={news.published_at}>{`${dateformat(news.published_at, 'dd.mm.yyyy')}`}</time></p>}
-            </div>
-          ))}
+                {news.published_at && (
+                  <p className={styles.articleDate}>
+                    <time dateTime={news.published_at}>{`${dateformat(
+                      news.published_at,
+                      'dd.mm.yyyy'
+                    )}`}</time>
+                  </p>
+                )}
+              </div>
+            ))}
         </div>
-        {paginatedNews && total > paginatedNews.length && (
+
+        {!field_short_list  && paginatedNews && total > paginatedNews.length && (
           <div className={styles.loadMore}>
             <HDSButton
               variant='supplementary'
@@ -86,12 +104,12 @@ function NewsList(props: NewsListProps): JSX.Element {
               style={{ background: 'none' }}
               onClick={() => {
                 setNewsIndex(newsIndex + 1)
-              }}
-            >
+              }}>
               {loadMoreText}
             </HDSButton>
           </div>
         )}
+
       </Container>
     </div>
   )

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -10,7 +10,7 @@ const baseQueryParams = () =>
       'field_content.field_liftup_with_image_image.field_media_image',
       'field_content.field_image.field_media_image',
       'field_content.field_background_color',
-      'field_notification'
+      'field_notification',
     ])
     .addFields(CONTENT_TYPES.MEDIA_IMAGE, [
       'field_media_image',
@@ -138,7 +138,8 @@ const getLandingPageQueryParams = () =>
     .addFields(CONTENT_TYPES.NEWS_LIST, [
       'field_title',
       'field_short_list',
-      'field_news_list_desc'
+      'field_news_list_desc',
+      'field_background_color',
     ])
     .getQueryObject()
 
@@ -186,6 +187,7 @@ export const baseArticlePageQueryParams = () =>
       'field_content',
       'status',
       'published_at',
+      'field_add_to_news_lift'
     ])
     .addFields(CONTENT_TYPES.TEXT, [
       'field_text'

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -187,7 +187,6 @@ export const baseArticlePageQueryParams = () =>
       'field_content',
       'status',
       'published_at',
-      'field_add_to_news_lift'
     ])
     .addFields(CONTENT_TYPES.TEXT, [
       'field_text'

--- a/src/lib/ssr-api.ts
+++ b/src/lib/ssr-api.ts
@@ -21,10 +21,10 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
         .addFilter('field_location_id', locationId)
         .getQueryObject()
 
-    return await getResourceCollection(NODE_TYPES.EVENT, { 
+    return await getResourceCollection(NODE_TYPES.EVENT, {
       locale,
       defaultLocale,
-      params: filteredEventParams() 
+      params: filteredEventParams()
     })
   }
 
@@ -34,10 +34,10 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
         .addFilter('field_tags', tags, 'IN')
         .getQueryObject()
 
-    return await getResourceCollection(NODE_TYPES.EVENT, { 
+    return await getResourceCollection(NODE_TYPES.EVENT, {
       locale,
       defaultLocale,
-      params: filteredEventParams() 
+      params: filteredEventParams()
     })
   }
 
@@ -47,17 +47,17 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
         .addFilter('field_location_id', locationId)
         .getQueryObject()
 
-    return await getResourceCollection(NODE_TYPES.EVENT, { 
+    return await getResourceCollection(NODE_TYPES.EVENT, {
       locale,
       defaultLocale,
-      params: filteredEventParams() 
+      params: filteredEventParams()
     })
   }
 
-  return await getResourceCollection(NODE_TYPES.EVENT, { 
+  return await getResourceCollection(NODE_TYPES.EVENT, {
     locale,
     defaultLocale,
-    params: eventParams().getQueryObject() 
+    params: eventParams().getQueryObject()
   })
 }
 
@@ -68,9 +68,10 @@ export const getNews = async (shortList: string, locale: Locale) => {
     const newsParamsLimited = () =>
       baseArticlePageQueryParams()
         .addSort('created', 'DESC')
+        .addFilter("status", "1")
         .addPageLimit(4)
 
-    return await getResourceCollection(NODE_TYPES.ARTICLE, { 
+    return await getResourceCollection(NODE_TYPES.ARTICLE, {
       params: newsParamsLimited().getQueryObject(),
       locale,
       defaultLocale
@@ -80,24 +81,25 @@ export const getNews = async (shortList: string, locale: Locale) => {
   const newsParams = () =>
     baseArticlePageQueryParams()
       .addSort('created', 'DESC')
+      .addFilter("status", "1")
       .addFilter('langcode', locale)
 
-  return await getResourceCollection(NODE_TYPES.ARTICLE, { 
+  return await getResourceCollection(NODE_TYPES.ARTICLE, {
     locale,
     defaultLocale,
-    params: newsParams().getQueryObject() 
+    params: newsParams().getQueryObject()
   })
 }
 
 export const getUnits = async (locale: Locale) => {
   const defaultLocale: Locale = 'fi'
-  
+
   const unitsParams = () =>
     baseTprUnitQueryParams()
       .addFilter('menu_link', null, 'IS NOT NULL')
       .addSort('name_override', 'ASC')
 
-  return await getResourceCollection(NODE_TYPES.TPR_UNIT, { 
+  return await getResourceCollection(NODE_TYPES.TPR_UNIT, {
     locale,
     defaultLocale,
     params: unitsParams().getQueryObject() })
@@ -126,10 +128,10 @@ const RETRY_LIMIT = 10
 export const getNode = async (props: GetNodeProps) => {
   const { type, context, drupal, path, retry = 0 } = props
 
-  const getter: any = () => 
+  const getter: any = () =>
     drupal.getResourceFromContext<Node>(type, context, {
       params: getQueryParamsFor(type),
-    })  
+    })
     .catch((e: any) => {
       console.log(`Error requesting node %s`, path.entity.path, {
         type,


### PR DESCRIPTION
Short list functionality now works on news list paragraph. When short list is selected the list brings 4 first published article to the list without the "show more" button. Added background drop-down selection to the news list paragraph so we can create short news list to the pages with background. When background selection is left blank the background colour is white. 

**question**
src/lib/ssr-api.ts I added `.addFilter("status", "1")` to the rows 71 and 84. to filter only published news. Earlier I have added `.filter((newsArticle: News) => newsArticle.status !== false)` in file src/components/news/NewsList.tsx to make sure that we get only published news. Should I remove the earlier added filter `.filter((newsArticle: News) => newsArticle.status !== false)` or leave it there. It's doesn’t matter there but it's unnecessary.

How to test:
- test with related Drupal PR https://github.com/City-of-Helsinki/drupal-employment-services/pull/132
- Start editing example main page 
- Add paragraph news list
- Give background colour and enable short list
<img width="1186" alt="Screenshot 2023-03-29 at 13 47 21" src="https://user-images.githubusercontent.com/42113018/228510542-cbc473ed-f670-4118-ba12-737b3205b0c0.png">
- you should now see news list on front page without the show more tab and with background
<img width="1559" alt="Screenshot 2023-03-29 at 13 53 10" src="https://user-images.githubusercontent.com/42113018/228511836-dd07ab78-43ee-4702-a4c5-d32c1284e94c.png">
- edit the paragraph again and leave the background blank 
- the background should now be white.

