### PR TITLE
Thf 486 link of list fix

### DIFF
--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -173,6 +173,7 @@ const getEventPageQueryParams = () =>
 export const baseArticlePageQueryParams = () =>
   new DrupalJsonApiParams()
     .addInclude([
+      'field_content.field_list_of_links_links.field_list_of_links_image.field_media_image',
       'field_content.field_image.field_media_image',
     ])
     .addFields(NODE_TYPES.ARTICLE, [
@@ -203,6 +204,17 @@ export const baseArticlePageQueryParams = () =>
       'field_quote_author_first_name',
       'field_quote_author_last_name',
       'field_quote_author_title'
+    ])
+    .addFields(CONTENT_TYPES.LIST_OF_LINKS, [
+      'field_list_of_links_design',
+      'field_list_of_links_links',
+      'field_list_of_links_title',
+      'field_background_color'
+    ])
+    .addFields(CONTENT_TYPES.LIST_OF_LINKS_ITEM, [
+      'field_list_of_links_link',
+      'field_list_of_links_image',
+      'field_list_of_links_desc',
     ])
 
 const getArticlePageQueryParams = () =>


### PR DESCRIPTION
Link of list Paragraph wasn’t working on Article page. Added link of list and link of items paragraphs (which is inside the list of links) to the article page. 

how to test:
- verify the bug first in develop branch
- create new article and add link-of-list paragraph 
- you should get an error after saving the page
- switch to the branch
- go to the created article and you should not get the error