### PR TITLE
THF-496: Move getLanguageLinks to slug

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -4,7 +4,7 @@ import ErrorPage from 'next/error'
 import { GetStaticPropsContext, GetStaticPathsContext, GetStaticPathsResult, GetStaticPropsResult } from 'next'
 import getConfig from 'next/config'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { Locale } from 'next-drupal'
+import { DrupalNode, Locale } from 'next-drupal'
 import { useTranslation } from 'next-i18next'
 import { Container } from 'hds-react'
 
@@ -19,11 +19,12 @@ import { getDrupalClient } from '@/lib/drupal-client'
 import getMenu from '@/lib/get-menu'
 import { Node, NavProps, FooterProps } from '@/lib/types'
 import { NODE_TYPES } from '@/lib/drupalApiTypes'
-import { getQueryParamsFor } from '@/lib/params'
 import { getNode } from '@/lib/ssr-api'
-import { getBreadCrumb, getDefaultImage, getDescription, getLanguageLinks, getPathAlias, getTitle } from '@/lib/helpers'
+import { getBreadCrumb, getDefaultImage, getDescription, getPathAlias, getTitle } from '@/lib/helpers'
 import { useConsentStatus, useReactAndShare } from '@/hooks/useAnalytics'
 import ConsentInfo from '@/components/consentInfo/ConsentInfo'
+import { i18n } from '@/next-i18next.config'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 
 interface PageProps {
   node: Node
@@ -40,69 +41,114 @@ export async function getStaticPaths(context: GetStaticPathsContext): Promise<Ge
     types = []
   }
 
-  const paths = await drupal.getStaticPathsFromContext(types, context)
+  const paths = await drupal.getStaticPathsFromContext(types, context);
 
   return {
     paths: paths,
-    fallback: true
-  }
+    fallback: true,
+  };
 }
 
-export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-  const { REVALIDATE_TIME, BUILD_PHASE } = getConfig().serverRuntimeConfig
-  const { locale, defaultLocale } = context as { locale: Locale, defaultLocale: Locale }
-  let withAuth = false
+export async function getStaticProps(
+  context: GetStaticPropsContext
+): Promise<GetStaticPropsResult<PageProps>> {
+  const { REVALIDATE_TIME, BUILD_PHASE } = getConfig().serverRuntimeConfig;
+  const { locale, defaultLocale } = context as {
+    locale: Locale;
+    defaultLocale: Locale;
+  };
+  let withAuth = false;
 
   // Use auth with preview to see unpublished content.
   if (context.preview) {
-    withAuth = true
+    withAuth = true;
   }
-  
-  const drupal = getDrupalClient(withAuth)
 
-  const path = await drupal.translatePathFromContext(context)
-  const type = path?.jsonapi?.resourceName
+  const drupal = getDrupalClient(withAuth);
+
+  const path = await drupal.translatePathFromContext(context);
+  const type = path?.jsonapi?.resourceName;
 
   if (!type) {
     return {
       notFound: true,
-      revalidate: 3
-    }
+      revalidate: 3,
+    };
   }
 
-  const entityLangcode = path?.entity?.langcode
+  const entityLangcode = path?.entity?.langcode;
   // If page(path) doesn't exist on current language.
   if (locale !== entityLangcode) {
     return {
       notFound: true,
-      revalidate: 3
-    }
+      revalidate: 3,
+    };
   }
 
-  let node: any = {}
+  let node: any = {};
 
   if (BUILD_PHASE) {
     // Try a few times, sometimes Drupal router just gives random errors.
-    node = await getNode({type, context, drupal, path, retry: 5})
+    node = await getNode({ type, context, drupal, path, retry: 5 });
   } else {
-    node = await getNode({type, context, drupal, path})
+    node = await getNode({ type, context, drupal, path });
   }
 
   // Return 404 if node was null
   if (!node || node?.notFound || (!context.preview && node?.status === false)) {
     return {
       notFound: true,
-      revalidate: 3
-    }
+      revalidate: 3,
+    };
   }
 
-  const langLinks = await getLanguageLinks(node)
+  async function getLanguageLinks(node: DrupalNode): Promise<Object> {
+    let params = new DrupalJsonApiParams()
+      .addFields(node.type, ['path'])
+      .getQueryObject();
+    const uuid = node.id;
 
-  const { tree: menu, items: menuItems } = await getMenu('main', locale, defaultLocale)
-  const { tree: themes } = await getMenu('additional-languages', locale, defaultLocale)
-  const { tree: footerNav } = await getMenu('footer', locale, defaultLocale)
+    let langLinks = {};
+    for (let locale of i18n.locales) {
+      let prefix = locale !== i18n.defaultLocale ? `/${locale}` : '';
+      let link = '';
+      if (locale === node.langcode) {
+        link = `${prefix}${node?.path.alias}`; // current page link
+      } else {
+        // this has the original alias if not translated
+        const response = await drupal.getResource(node.type, uuid, {
+          params,
+          locale,
+          defaultLocale: i18n.defaultLocale,
+        });
+        link = `${prefix}${response?.path.alias}`;
+      }
+      Object.assign(langLinks, { [locale]: link });
+    }
 
-  const breadcrumb = getBreadCrumb(menuItems, getPathAlias(node?.path), node?.title, node?.type)
+    return langLinks;
+  }
+
+  const langLinks = await getLanguageLinks(node);
+
+  const { tree: menu, items: menuItems } = await getMenu(
+    'main',
+    locale,
+    defaultLocale
+  );
+  const { tree: themes } = await getMenu(
+    'additional-languages',
+    locale,
+    defaultLocale
+  );
+  const { tree: footerNav } = await getMenu('footer', locale, defaultLocale);
+
+  const breadcrumb = getBreadCrumb(
+    menuItems,
+    getPathAlias(node?.path),
+    node?.title,
+    node?.type
+  );
 
   return {
     props: {
@@ -120,26 +166,30 @@ export async function getStaticProps(context: GetStaticPropsContext): Promise<Ge
       },
       ...(await serverSideTranslations(locale, ['common'])),
     },
-    revalidate: REVALIDATE_TIME
-  }
+    revalidate: REVALIDATE_TIME,
+  };
 }
 
 export default function Page({ node, nav, footer }: PageProps) {
-  const router = useRouter()
-  const { t } = useTranslation('common')
-  const rnsStatus: boolean = useConsentStatus('rns')
-  useReactAndShare(rnsStatus, router.locale, node && getTitle(node, t('site_title')))
+  const router = useRouter();
+  const { t } = useTranslation('common');
+  const rnsStatus: boolean = useConsentStatus('rns');
+  useReactAndShare(
+    rnsStatus,
+    router.locale,
+    node && getTitle(node, t('site_title'))
+  );
 
   if (!router.isFallback && !node?.id) {
-    return <ErrorPage statusCode={404} />
+    return <ErrorPage statusCode={404} />;
   }
 
-  if (!node) return null
+  if (!node) return null;
 
-  const metaTitle = getTitle(node, t('site_title'))
-  const metaDescription = getDescription(node)
-  const metaUrl = process.env.NEXT_PUBLIC_SITE_URL + router.asPath
-  const metaImage = getDefaultImage(node)
+  const metaTitle = getTitle(node, t('site_title'));
+  const metaDescription = getDescription(node);
+  const metaUrl = process.env.NEXT_PUBLIC_SITE_URL + router.asPath;
+  const metaImage = getDefaultImage(node);
 
   return (
     <Layout header={nav} footer={footer}>
@@ -152,27 +202,19 @@ export default function Page({ node, nav, footer }: PageProps) {
         <meta property="og:url" content={metaUrl} />
         <meta property="og:image" content={metaImage} />
       </Head>
-      { node.type === NODE_TYPES.PAGE && (
+      {node.type === NODE_TYPES.PAGE && (
         <NodeBasicPage node={node} sidebar={nav} />
       )}
-      { node.type === NODE_TYPES.LANDING_PAGE && (
-        <NodeLandingPage node={node} />
-      )}
-      { node.type === NODE_TYPES.EVENT && (
-        <NodeEventPage node={node} />
-      )}
-      { node.type === NODE_TYPES.ARTICLE && (
-        <NodeArticlePage node={node} />
-      )}
-      { node.type === NODE_TYPES.TPR_UNIT && (
+      {node.type === NODE_TYPES.LANDING_PAGE && <NodeLandingPage node={node} />}
+      {node.type === NODE_TYPES.EVENT && <NodeEventPage node={node} />}
+      {node.type === NODE_TYPES.ARTICLE && <NodeArticlePage node={node} />}
+      {node.type === NODE_TYPES.TPR_UNIT && (
         <NodeTprUnitPage node={node} sidebar={nav} />
       )}
       {/* React and share */}
       <Container className="container hide-print">
-        <div className="rns">
-          {rnsStatus !== true ? <ConsentInfo /> : ''}
-        </div>
+        <div className="rns">{rnsStatus !== true ? <ConsentInfo /> : ''}</div>
       </Container>
     </Layout>
-  )
+  );
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,76 +1,76 @@
-import { NextApiResponse } from "next"
-import { DrupalMenuLinkContent, DrupalNode, getResource } from "next-drupal"
-import { DrupalJsonApiParams } from "drupal-jsonapi-params"
-import { Node } from '@/lib/types'
-import getConfig from 'next/config'
+import { NextApiResponse } from "next";
+import { DrupalMenuLinkContent, DrupalNode, getResource } from "next-drupal";
+import { Node } from "@/lib/types";
+import getConfig from "next/config";
 
-import { i18n } from "next-i18next.config"
 
-import { BreadcrumbContent } from "./types"
-import { NODE_TYPES } from '@/lib/drupalApiTypes'
+import { BreadcrumbContent } from "./types";
+import { NODE_TYPES } from "@/lib/drupalApiTypes";
 
-export const eventTags = ['maahanmuuttajat', 'nuoret', 'info', 'koulutus', 'messut', 'neuvonta', 'rekrytointi', 'työpajat', 'digitaidot', 'etätapahtuma', 'palkkatuki', 'työnhaku']
-export const printablePages = [NODE_TYPES.ARTICLE, NODE_TYPES.EVENT, NODE_TYPES.PAGE, NODE_TYPES.TPR_UNIT]
+export const eventTags = [
+  "maahanmuuttajat",
+  "nuoret",
+  "info",
+  "koulutus",
+  "messut",
+  "neuvonta",
+  "rekrytointi",
+  "työpajat",
+  "digitaidot",
+  "etätapahtuma",
+  "palkkatuki",
+  "työnhaku",
+];
+export const printablePages = [
+  NODE_TYPES.ARTICLE,
+  NODE_TYPES.EVENT,
+  NODE_TYPES.PAGE,
+  NODE_TYPES.TPR_UNIT,
+];
 
-export const isExternalLink = (href: string): boolean|undefined => {
-  const isExternalLink = href && (href.startsWith('https://') || href.startsWith('https://'))
+export const isExternalLink = (href: string): boolean | undefined => {
+  const isExternalLink =
+    href && (href.startsWith('https://') || href.startsWith('https://'));
 
-  return isExternalLink || false
-}
+  return isExternalLink || false;
+};
 
 export const getImageUrl = (url: string): string => {
   if (!url) {
-    return ''
+    return '';
   }
 
-  const host = getConfig().publicRuntimeConfig.NEXT_IMAGE_DOMAIN
-  url = url.substring(url.indexOf('/sites'))
+  const host = getConfig().publicRuntimeConfig.NEXT_IMAGE_DOMAIN;
+  url = url.substring(url.indexOf('/sites'));
 
-  return url ? `https://${host}${url}` : ''
+  return url ? `https://${host}${url}` : '';
 }
 
 export const getPath = (url: string): string => {
-  const newUrl = new URL(url)
+  const newUrl = new URL(url);
 
-  return (newUrl.pathname)
-}
+  return newUrl.pathname;
+};
 
 export const getPathAlias = (path: any): string => {
   if (!path) {
-    return ''
+    return "";
   }
 
   return path.langcode === 'fi' ? path.alias : `/${path.langcode}${path.alias}`
 }
 
-
-export async function getLanguageLinks(node: DrupalNode): Promise<Object> {
-  let params = new DrupalJsonApiParams().addFields(node.type, ['path']).getQueryObject()
-  const uuid = node.id
-
-  let langLinks = {}
-  for (let locale of i18n.locales) {
-    let prefix = locale !== i18n.defaultLocale ? `/${locale}` : ''
-    let link = ''
-    if (locale === node.langcode) {
-      link = `${prefix}${node?.path.alias}` // current page link
-    } else {
-      // this has the original alias if not translated
-      const response = await getResource(node.type, uuid, {params, locale, defaultLocale: i18n.defaultLocale})
-      link = `${prefix}${response?.path.alias}`
-    }
-    Object.assign(langLinks, {[locale]: link})
-  }
-
-  return langLinks
-}
-
-export const getBreadCrumb = (menuItems: DrupalMenuLinkContent[], path: string, title: string, type: string): BreadcrumbContent[] => {
-  const page = menuItems.find(({ url }) => url === path)
+export const getBreadCrumb = (
+  menuItems: DrupalMenuLinkContent[],
+  path: string,
+  title: string,
+  type: string
+): BreadcrumbContent[] => {
+  const page = menuItems.find(({ url }) => url === path);
 
   // TPR Unit may not have menu attachment
-  if (!page && (type === 'tpr_unit--tpr_unit')) {
-    return []
+  if (!page && type === 'tpr_unit--tpr_unit') {
+    return [];
   }
 
   // Breadcrumb object for pages without menu attachment
@@ -78,144 +78,154 @@ export const getBreadCrumb = (menuItems: DrupalMenuLinkContent[], path: string, 
     id: 'current_page_crumb',
     title: title,
     url: path,
-    parent: ''
-  }
+    parent: '',
+  };
 
   // Pages that are not in menus always get a breadcrumb.
   if (!page) {
     // Custom breadcrumb for Event pages
     if (type !== 'node--event') {
-      return [newPage]
+      return [newPage];
     }
 
     // Read parent from the page path
-    const parentPath = path.substring(0, path.lastIndexOf('/'))
+    const parentPath = path.substring(0, path.lastIndexOf('/'));
     // Load parent menu object
-    const parentPage = menuItems.find(({ url }) => url.includes(parentPath))
+    const parentPage = menuItems.find(({ url }) => url.includes(parentPath));
 
     // Event page doesn't have parent
     if (!parentPage?.id) {
-      return [newPage]
+      return [newPage];
     }
 
     // Create parent id for the page
-    newPage.parent = parentPage.id
+    newPage.parent = parentPage.id;
   }
 
   // Landing pages don't need breadcrumb.
   if (page?.parent === '') {
-    return []
+    return [];
   }
 
   // Create handle for the page object based on above
-  const pageHandle: any = newPage.parent !== '' ? newPage : page
+  const pageHandle: any = newPage.parent !== '' ? newPage : page;
 
-  const breadcrumbs: BreadcrumbContent[] = [pageHandle]
-  let parentItem = menuItems.find(({ id }) => id === pageHandle.parent)
+  const breadcrumbs: BreadcrumbContent[] = [pageHandle];
+  let parentItem = menuItems.find(({ id }) => id === pageHandle.parent);
 
   if (parentItem) {
-    breadcrumbs.push(parentItem)
+    breadcrumbs.push(parentItem);
     // This should always exit early and never infloop.
-    for (let i=0; i < menuItems.length; i++) {
-      parentItem = menuItems.find(({ id }) => id === parentItem?.parent)
+    for (let i = 0; i < menuItems.length; i++) {
+      parentItem = menuItems.find(({ id }) => id === parentItem?.parent);
       if (parentItem) {
-        breadcrumbs.push(parentItem)
+        breadcrumbs.push(parentItem);
       }
-      if (!parentItem?.parent) break
+      if (!parentItem?.parent) break;
     }
   }
-  return breadcrumbs.reverse()
-}
+  return breadcrumbs.reverse();
+};
 
 export const deleteCookie = (event: any, name: string, history: any) => {
-  event.preventDefault()
-  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`
-  history.go(0)
-}
+  event.preventDefault();
+  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  history.go(0);
+};
 
 export const getTitle = (node: Node, suffix: String): string => {
-  let pageTitle = node.title
+  let pageTitle = node.title;
 
   if (node.type === 'tpr_unit--tpr_unit') {
-    pageTitle = node.name_override ? node.name_override : node.name
+    pageTitle = node.name_override ? node.name_override : node.name;
   }
 
-  const title = node.field_metatags?.title ? node.field_metatags.title : pageTitle
-  return suffix ? `${title} | ${suffix}` : title
-}
+  const title = node.field_metatags?.title
+    ? node.field_metatags.title
+    : pageTitle;
+  return suffix ? `${title} | ${suffix}` : title;
+};
 
 export const getDescription = (node: Node): any => {
   if (node.field_metatags?.description) {
-    return node.field_metatags.description
+    return node.field_metatags.description;
   }
 
   switch (node.type) {
     case 'node--page':
-      return node.field_lead_in
+      return node.field_lead_in;
 
     case 'node--landing_page':
       if (!node.field_hero?.field_hero_desc) {
-        break
+        break;
       }
-      return node.field_hero.field_hero_desc.processed.replace(/(<([^>]+)>)/gi, "")
+      return node.field_hero.field_hero_desc.processed.replace(
+        /(<([^>]+)>)/gi,
+        ''
+      );
 
     case 'node--event':
       if (!node?.field_short_description) {
-        break
+        break;
       }
-      return node.field_short_description.processed.replace(/(<([^>]+)>)/gi, "")
+      return node.field_short_description.processed.replace(
+        /(<([^>]+)>)/gi,
+        ''
+      );
 
     case 'node--article':
       if (!node?.field_lead) {
-        break
+        break;
       }
-      return node.field_lead
+      return node.field_lead;
 
     case 'tpr_unit--tpr_unit':
       if (!node?.description) {
-        break
+        break;
       }
-      return node.description.value
+      return node.description.value;
 
     default:
-      break
+      break;
   }
 
-  return ''
-}
+  return '';
+};
 
 export const getDefaultImage = (node: Node): string => {
   switch (node.type) {
     case 'node--event':
       if (!node?.field_image_url) {
-        break
+        break;
       }
-      return node.field_image_url
+      return node.field_image_url;
 
     case 'node--landing_page':
       if (!node?.field_hero) {
-        break
+        break;
       }
-      return node.field_hero.field_custom_hero_image?.field_media_image?.image_style_uri?.['hero']
+      return node.field_hero.field_custom_hero_image?.field_media_image
+        ?.image_style_uri?.['hero'];
 
     default:
-      break
+      break;
   }
 
-  return process.env.NEXT_PUBLIC_SITE_URL + "/tyollisyyspalvelut.png"
-}
+  return process.env.NEXT_PUBLIC_SITE_URL + '/tyollisyyspalvelut.png';
+};
 
 export const sortArrayByOtherArray = (array: any[], sortArray: string[]) => {
   return [...array].sort(
-    (a , b) => sortArray.indexOf(a.name_override) - sortArray.indexOf(b.name_override)
-  )
-}
+    (a, b) =>
+      sortArray.indexOf(a.name_override) - sortArray.indexOf(b.name_override)
+  );
+};
 
 export const getLocale = (res: NextApiResponse<any>) => {
-  const host = res.req.headers.host
+  const host = res.req.headers.host;
   const url = res.req.headers.referer
     ?.replace(`http://${host}/`, '')
-    .slice(0, 2)
-  const locale = url === 'en' || url === 'sv' ? url : 'fi'
-  return locale
-}
+    .slice(0, 2);
+  const locale = url === 'en' || url === 'sv' ? url : 'fi';
+  return locale;
+};


### PR DESCRIPTION
Moved getLanguageLinks to slug so that  we are able to make getResource call vie drupal server.


How to test:

- run `yarn build` and see that you don't have any errors
- then check few pages to see that the pages work.