### PR TITLE
THF-510: Add hyphens: auto

### DIFF
--- a/src/components/hero/hero.module.scss
+++ b/src/components/hero/hero.module.scss
@@ -18,6 +18,15 @@
   h1 {
     font-size: var(--fontsize-heading-xl);
   }
+  @media (max-width: $breakpoint-s) {
+    h1 {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      -webkit-hyphens: auto;
+      -moz-hyphens: auto;
+      hyphens: auto;
+    }
+  }
 }
 
 .heroTextContent {


### PR DESCRIPTION
Hero header text wasn't working in Swedish. Added Hyphens to cut the word when on mobile. 

How to test:

- Go to main page http://localhost:3000/sv
- try the page with Developer tools and mobile size screen
- see that the layout looks same all languages