### PR TITLE
THF-469: preview functionality to nav

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -30,7 +30,7 @@ interface PageProps {
   node: Node;
   nav: NavProps;
   footer: FooterProps;
-  preview: any;
+  preview: boolean | undefined;
 }
 
 export async function getStaticPaths(context: GetStaticPathsContext): Promise<GetStaticPathsResult> {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -27,9 +27,10 @@ import { i18n } from '@/next-i18next.config'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 
 interface PageProps {
-  node: Node
-  nav: NavProps
-  footer: FooterProps
+  node: Node;
+  nav: NavProps;
+  footer: FooterProps;
+  preview: any;
 }
 
 export async function getStaticPaths(context: GetStaticPathsContext): Promise<GetStaticPathsResult> {
@@ -130,7 +131,7 @@ export async function getStaticProps(
   }
 
   const langLinks = await getLanguageLinks(node);
-
+  
   const { tree: menu, items: menuItems } = await getMenu(
     'main',
     locale,
@@ -142,6 +143,7 @@ export async function getStaticProps(
     defaultLocale
   );
   const { tree: footerNav } = await getMenu('footer', locale, defaultLocale);
+  const preview = context.preview ? context.preview : false;
 
   const breadcrumb = getBreadCrumb(
     menuItems,
@@ -153,6 +155,7 @@ export async function getStaticProps(
   return {
     props: {
       node,
+      preview,
       nav: {
         locale,
         menu,
@@ -170,7 +173,7 @@ export async function getStaticProps(
   };
 }
 
-export default function Page({ node, nav, footer }: PageProps) {
+export default function Page({ node, nav, footer, preview }: PageProps) {
   const router = useRouter();
   const { t } = useTranslation('common');
   const rnsStatus: boolean = useConsentStatus('rns');
@@ -192,7 +195,7 @@ export default function Page({ node, nav, footer }: PageProps) {
   const metaImage = getDefaultImage(node);
   
   return (
-    <Layout header={nav} footer={footer} hideNav={node.field_hide_navigation}>
+    <Layout header={nav} footer={footer} hideNav={node.field_hide_navigation} preview={preview}>
       <Head>
         <title>{metaTitle}</title>
         <meta name="description" content={metaDescription} />
@@ -204,7 +207,7 @@ export default function Page({ node, nav, footer }: PageProps) {
       </Head>
       <a id="content" tabIndex={-1}></a>
       { node.type === NODE_TYPES.PAGE && (
-        <NodeBasicPage node={node} sidebar={nav} />
+        <NodeBasicPage node={node} sidebar={nav} preview={preview}/>
       )}
       {node.type === NODE_TYPES.LANDING_PAGE && (
         <NodeLandingPage node={node} />
@@ -212,7 +215,7 @@ export default function Page({ node, nav, footer }: PageProps) {
       {node.type === NODE_TYPES.EVENT && <NodeEventPage node={node} />}
       {node.type === NODE_TYPES.ARTICLE && <NodeArticlePage node={node} />}
       {node.type === NODE_TYPES.TPR_UNIT && (
-        <NodeTprUnitPage node={node} sidebar={nav} />
+        <NodeTprUnitPage node={node} sidebar={nav} preview={preview}/>
       )}
       {/* React and share */}
       <Container className="container hide-print">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,6 +11,7 @@ interface LayoutProps {
   header: NavProps;
   footer: FooterProps;
   hideNav?: boolean;
+  preview?: boolean;
 }
 
 export function Layout({
@@ -18,12 +19,13 @@ export function Layout({
   header,
   footer,
   hideNav,
+  preview,
 }: LayoutProps): JSX.Element {
   return (
     <>
       <PreviewAlert />
       <div className={styles.wrapper}>
-        <Header {...header} hideNav={hideNav} />
+        <Header {...header} hideNav={hideNav} preview={preview}/>
         <main>{children}</main>
       </div>
       <Footer {...footer} />

--- a/src/components/navigation/Breadcrumb.tsx
+++ b/src/components/navigation/Breadcrumb.tsx
@@ -1,39 +1,56 @@
 import { IconAngleRight, IconArrowRight } from "hds-react"
-import Link from "next/link"
+import { Link } from 'hds-react';
 import { ReactElement } from "react"
 import { useTranslation } from 'next-i18next'
 
 import classNames from "@/lib/classNames"
 import { BreadcrumbContent } from "@/lib/types"
-
+import { previewNavigation } from '@/lib/helpers';
 import styles from './navigation.module.scss'
 
 interface BreadcrumbProps {
-  breadcrumb: BreadcrumbContent[]
+  breadcrumb: BreadcrumbContent[];
+  preview: boolean | undefined;
 }
 
-export const Breadcrumb = ({breadcrumb}:BreadcrumbProps): JSX.Element => {
-  const { t } = useTranslation('common')
+export const Breadcrumb = ({ breadcrumb, preview }: BreadcrumbProps): JSX.Element => {
+  const { t } = useTranslation('common');
 
-  if (!breadcrumb || breadcrumb.length == 0) return <></>
+  if (!breadcrumb || breadcrumb.length == 0) return <></>;
 
   const crumbs: ReactElement[] = breadcrumb.map((crumb, index) => {
-    if (index == breadcrumb.length-1) {
-      return <div className={styles.breadcrumbElement} key={crumb.id}><span>{crumb.title}</span></div>
+    if (index == breadcrumb.length - 1) {
+      return (
+        <div className={styles.breadcrumbElement} key={crumb.id}>
+          <span>{crumb.title}</span>
+        </div>
+      );
     }
     return (
       <div className={styles.breadcrumbElement} key={crumb.id}>
-        <Link href={crumb.url}><a><span>{crumb.title}</span></a></Link><IconAngleRight size='s' aria-hidden='true'/>
+        <Link
+          href={crumb.url}
+          onClick={() => previewNavigation(crumb.url, preview)}
+        >
+          <span>{crumb.title}</span>
+        </Link>
+        <IconAngleRight size="s" aria-hidden="true" />
       </div>
-    )
-  })
+    );
+  });
 
   return (
-    <nav className={classNames(styles.breadcrumb)} aria-label={t("navigation.breadcrumb_label")}>
-      <div className={styles.breadcrumbElement} key='breadcrumb-frontpage'>
-        <Link href="/"><a><span>{t("navigation.frontpage")}</span></a></Link><IconAngleRight size='s' aria-hidden='true'/>
+    <nav
+      className={classNames(styles.breadcrumb)}
+      aria-label={t('navigation.breadcrumb_label')}
+    >
+      <div className={styles.breadcrumbElement} key="breadcrumb-frontpage">
+      <Link href="/" onClick={() => previewNavigation("/", preview)}>
+            <span>{t('navigation.frontpage')}</span>
+        </Link>
+        <IconAngleRight size="s" aria-hidden="true" />
       </div>
       {crumbs}
     </nav>
-  )
-}
+  );
+};

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -143,7 +143,7 @@ function Header(header: NavProps): JSX.Element {
       </Navigation>
       {activePath !== '/' && (
         <div className={styles.subHeader}>
-          <Breadcrumb breadcrumb={breadcrumb} />
+          <Breadcrumb breadcrumb={breadcrumb} preview={preview}/>
           {isPrintable && (
             <PrintButton
               onClick={() => window?.print()}

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -6,13 +6,14 @@ import { Navigation, IconArrowTopRight } from 'hds-react';
 
 import { NavProps } from '@/lib/types';
 import classNames from '@/lib/classNames';
-import { printablePages } from '@/lib/helpers';
+import { previewNavigation, printablePages } from '@/lib/helpers';
 import { Breadcrumb } from './Breadcrumb';
 import styles from './navigation.module.scss';
 import PrintButton from '../printButton/PrintButton';
 
 function Header(header: NavProps): JSX.Element {
-  const { locale, menu, themes, langLinks, breadcrumb, hideNav } = header;
+  const { locale, menu, themes, langLinks, breadcrumb, hideNav, preview } = header;
+  
   const { t } = useTranslation('common');
   const router: any = useRouter(); // @TODO Fix type for proper
   const activePath = langLinks[locale ? locale : 'fi'];
@@ -34,6 +35,7 @@ function Header(header: NavProps): JSX.Element {
     if (!menuArray) {
       return <></>;
     }
+
     menuArray.map((item: DrupalMenuLinkContent, index: number) => {
       const subs: ReactElement[] = [];
       let childActive = false;
@@ -46,6 +48,7 @@ function Header(header: NavProps): JSX.Element {
             href={sub.url}
             label={sub.title}
             active={sub.url === activePath}
+            onClick={() => previewNavigation(sub.url, preview)}
           />
         );
         return subs;
@@ -59,6 +62,7 @@ function Header(header: NavProps): JSX.Element {
           active={isActive}
           className={classNames(styles.navDropDown, isActive && styles.active)}
           href={item.url}
+          onClick={() => () => previewNavigation(item.url, preview)}
         >
           {subs}
         </Navigation.DropdownLink>
@@ -114,6 +118,7 @@ function Header(header: NavProps): JSX.Element {
               hrefLang='fi'
               label='Suomeksi'
               active={langLinks.fi === activePath}
+              onClick={() => previewNavigation(langLinks.fi, preview)}
             />
             <Navigation.Item
               lang='sv'
@@ -122,6 +127,7 @@ function Header(header: NavProps): JSX.Element {
               hrefLang='sv'
               label='På svenska'
               active={langLinks.sv === activePath}
+              onClick={() => previewNavigation(langLinks.sv, preview)}
             />
             <Navigation.Item
               lang='en'
@@ -130,6 +136,7 @@ function Header(header: NavProps): JSX.Element {
               hrefLang='en'
               label='In English'
               active={langLinks.en === activePath}
+              onClick={() => previewNavigation(langLinks.en, preview)}
             />
           </Navigation.LanguageSelector>
         </Navigation.Actions>

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -5,36 +5,39 @@ import { DrupalMenuLinkContent } from "next-drupal"
 
 import classNames from "@/lib/classNames"
 import { NavProps } from "@/lib/types"
+import { previewNavigation } from "@/lib/helpers"
 
 import styles from './navigation.module.scss'
 
 
-export function Sidebar(sidebar:NavProps): JSX.Element {
-  const { locale, menu, langLinks } = sidebar;
+export function Sidebar(sidebar: NavProps): JSX.Element {
+  const { locale, menu, langLinks, preview } = sidebar;
   const { t } = useTranslation('common');
-  const activePath = langLinks[locale ? locale : 'fi']
+  const activePath = langLinks[locale ? locale : 'fi'];
 
-  const getSideNav = (menuArray: DrupalMenuLinkContent[]|undefined):{ nav: ReactElement[], defaultOpenMainLevels: number[] } => {
-    const nav: ReactElement[] = []
-    let defaultOpenMainLevels: number[] = []
+  const getSideNav = (
+    menuArray: DrupalMenuLinkContent[] | undefined
+  ): { nav: ReactElement[]; defaultOpenMainLevels: number[] } => {
+    const nav: ReactElement[] = [];
+    let defaultOpenMainLevels: number[] = [];
 
     if (!menuArray) {
-      return {nav, defaultOpenMainLevels}
+      return { nav, defaultOpenMainLevels };
     }
     menuArray.map((second: DrupalMenuLinkContent, index: number) => {
-      const subs: ReactElement[] = []
-      let parent: boolean = false
+      const subs: ReactElement[] = [];
+      let parent: boolean = false;
 
       second.items?.map((sub: DrupalMenuLinkContent, i: number) => {
         if (sub.url === activePath) {
-          parent = true
-          defaultOpenMainLevels.push(i+1)
+          parent = true;
+          defaultOpenMainLevels.push(i + 1);
         }
         if (sub.items) {
-          let thirds: ReactElement[] = []
+          let thirds: ReactElement[] = [];
           sub.items?.map((third: DrupalMenuLinkContent, idx: number) => {
             if (third.url === activePath) {
-              parent = true
+              parent = true;
             }
             thirds.push(
               <SideNavigation.SubLevel
@@ -42,60 +45,71 @@ export function Sidebar(sidebar:NavProps): JSX.Element {
                 id={third.title}
                 href={third.url}
                 label={third.title}
-                className={classNames(styles.subLevel, third.url === activePath && styles.active)}
+                className={classNames(
+                  styles.subLevel,
+                  third.url === activePath && styles.active
+                )}
                 active={third.url === activePath}
+                onClick={() => previewNavigation(third.url, preview)}
               />
-            )
-            return thirds
-          })
+            );
+            return thirds;
+          });
           subs.push(
             <SideNavigation.MainLevel
               key={sub.title}
               id={sub.title}
               // href={sub.url}
-              onClick={() => window.location.href = sub.url}
+              onClick={() => (window.location.href = sub.url)}
               label={sub.title}
-              className={classNames(styles.mainLevel, sub.url === activePath && styles.active)}
+              className={classNames(
+                styles.mainLevel,
+                sub.url === activePath && styles.active
+              )}
               active={sub.url === activePath}
             >
               {thirds}
             </SideNavigation.MainLevel>
-          )
-        }
-        else {
+          );
+        } else {
           subs.push(
             <SideNavigation.MainLevel
               key={sub.title}
               id={sub.title}
               href={sub.url}
               label={sub.title}
-              className={classNames(styles.mainLevel, sub.url === activePath && styles.active)}
+              className={classNames(
+                styles.mainLevel,
+                sub.url === activePath && styles.active
+              )}
               active={sub.url === activePath}
+              onClick={() => previewNavigation(sub.url, preview)}
             />
-          )
+          );
         }
-        return subs
-      })
+        return subs;
+      });
 
       if (parent || second.url === activePath) {
         nav.push(
           <SideNavigation.MainLevel
             key={second.title}
-            icon={<IconArrowLeft aria-hidden className={styles.wiggle}/>}
+            icon={<IconArrowLeft aria-hidden className={styles.wiggle} />}
             label={second.title}
             id={second.title}
             href={second.url}
             className={classNames(styles.topLevel)}
-
-          />
-        , ...subs)
+            onClick={() => previewNavigation(second.url, preview)}
+          />,
+          ...subs
+        );
       }
-      return nav
-    })
-    return {nav, defaultOpenMainLevels}
-  }
+      return nav;
+    });
+    return { nav, defaultOpenMainLevels };
+  };
 
-  const { nav, defaultOpenMainLevels } = getSideNav(menu)
+  const { nav, defaultOpenMainLevels } = getSideNav(menu);
 
   return (
     <SideNavigation
@@ -106,5 +120,5 @@ export function Sidebar(sidebar:NavProps): JSX.Element {
     >
       {nav}
     </SideNavigation>
-  )
+  );
 }

--- a/src/components/navigation/navigation.module.scss
+++ b/src/components/navigation/navigation.module.scss
@@ -198,10 +198,15 @@
   outline: none;
   padding: var(--spacing-3-xs) 0;
   span {
+    color: var(--color-black);
     margin: 0 var(--spacing-2-xs);
     font-weight: 600;
     font-size: var(--fontsize-body-s);
     line-height: var(--lineheight-s);
+  }
+  [class*="link_hds-link"] {
+    --link-visited-color: var(--color-black);
+    --link-color: var(--color-black);
   }
 }
 

--- a/src/components/pageTemplates/NodeBasicPage.tsx
+++ b/src/components/pageTemplates/NodeBasicPage.tsx
@@ -4,11 +4,12 @@ import ContentMapper from '@/components/ContentMapper'
 import { Sidebar } from '@/components/navigation/Sidebar'
 
 interface NodeBasicPageProps {
-  node: Node
-  sidebar: NavProps
+  node: Node;
+  sidebar: NavProps;
+  preview: boolean | undefined;
 }
 
-function NodeBasicPage({ node, sidebar, ...props }: NodeBasicPageProps): JSX.Element {
+function NodeBasicPage({ node, sidebar, preview, ...props }: NodeBasicPageProps): JSX.Element {
   const {
     title,
     field_lead_in,
@@ -25,7 +26,7 @@ function NodeBasicPage({ node, sidebar, ...props }: NodeBasicPageProps): JSX.Ele
         <div className="columns">
           {!field_hide_sidebar &&
           <div className="sidebar col col-4 flex-order-first">
-            <Sidebar {...sidebar}/>
+            <Sidebar {...sidebar} preview={preview}/>
           </div>
           }
           <div className={`content-region col col-8${!field_hide_sidebar ? " flex-grow" : "" }`}>

--- a/src/components/pageTemplates/NodeTprUnitPage.tsx
+++ b/src/components/pageTemplates/NodeTprUnitPage.tsx
@@ -19,23 +19,25 @@ import styles from './tprUnitPage.module.scss'
 import AccordionWithIcon from '../accordion/AccordionWithIcon'
 
 interface NodeTprUnitProps {
-  node: TprUnitData
-  sidebar: NavProps
+  node: TprUnitData;
+  sidebar: NavProps;
+  preview: boolean | undefined;
 }
 
 interface BlockProps {
-  title: string
-  icon: string
-  content: any
+  title: string;
+  icon: string;
+  content: any;
 }
 
 interface ContactInfoProps {
-  aside?: boolean
+  aside?: boolean;
 }
 
 function NodeTprUnitPage({
   node,
   sidebar,
+  preview,
   ...props
 }: NodeTprUnitProps): JSX.Element {
   const {
@@ -136,7 +138,7 @@ function NodeTprUnitPage({
       <Container className="container">
         <div className="columns">
           <div className="sidebar col col-4 flex-order-first">
-            <Sidebar {...sidebar}/>
+            <Sidebar {...sidebar} preview={preview}/>
             <ContactInfo aside={true} />
           </div>
           <div className="content-region col col-8 flex-grow">

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -238,3 +238,13 @@ export const groupData = (data: GroupingProps[]) => {
   );
   return groups;
 };
+
+export const previewNavigation = (path: string, preview: boolean | undefined): void => {
+  if (preview) {
+    window
+      .open(`${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${path}`, '_parent')
+      ?.focus();
+  } else {
+    return;
+  }
+};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -29,6 +29,17 @@ export const printablePages = [
   NODE_TYPES.TPR_UNIT,
 ];
 
+
+export const previewNavigation = (path: string, preview: boolean | undefined): void => {
+  if (preview) {
+    window
+      .open(`${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${path}`, '_parent')
+      ?.focus();
+  } else {
+    return;
+  }
+};
+
 export const isExternalLink = (href: string): boolean | undefined => {
   const isExternalLink =
     href && (href.startsWith('https://') || href.startsWith('https://'));
@@ -237,14 +248,4 @@ export const groupData = (data: GroupingProps[]) => {
     groups.indexOf(item.group) === -1 ? groups.push(item.group) : null
   );
   return groups;
-};
-
-export const previewNavigation = (path: string, preview: boolean | undefined): void => {
-  if (preview) {
-    window
-      .open(`${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${path}`, '_parent')
-      ?.focus();
-  } else {
-    return;
-  }
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface NavProps {
   langLinks?: any;
   breadcrumb?: any;
   hideNav?: boolean;
+  preview?: boolean;
 }
 
 export interface FooterProps {


### PR DESCRIPTION
Made Drupal follow preview IFrame's navigation url

How to test:

- go to https://drupal-tyollisyyspalvelut-helfi.docker.so/
- Navigate from Iframe Navigation to some other page than fron page. 
- The Drupal parent page should now follow the link from previews IFrame. 
- Go to https://drupal-tyollisyyspalvelut-helfi.docker.so/yhteystiedot/toimipisteet or other page that have sidebar
- Clicking a sidebar link. The link should take you right place and change the Drupal page url as well

Test also the breadcrumb

- the the appearance shouldn’t have changed
- The text should be black with any hover effect
- The pointer should be pointer as in other links.
- Next.js you should not have any changes
- Go to Drupal and some article
- Navigate back to Current matter page
- Drupal parent page url should go to this page.