### PR TITLE
THF-469: Remove span from link

### DIFF
--- a/src/components/navigation/Breadcrumb.tsx
+++ b/src/components/navigation/Breadcrumb.tsx
@@ -32,7 +32,7 @@ export const Breadcrumb = ({ breadcrumb, preview }: BreadcrumbProps): JSX.Elemen
           href={crumb.url}
           onClick={() => previewNavigation(crumb.url, preview)}
         >
-          <span>{crumb.title}</span>
+          {crumb.title}
         </Link>
         <IconAngleRight size="s" aria-hidden="true" />
       </div>
@@ -46,7 +46,7 @@ export const Breadcrumb = ({ breadcrumb, preview }: BreadcrumbProps): JSX.Elemen
     >
       <div className={styles.breadcrumbElement} key="breadcrumb-frontpage">
       <Link href="/" onClick={() => previewNavigation("/", preview)}>
-            <span>{t('navigation.frontpage')}</span>
+           {t('navigation.frontpage')}
         </Link>
         <IconAngleRight size="s" aria-hidden="true" />
       </div>

--- a/src/components/navigation/navigation.module.scss
+++ b/src/components/navigation/navigation.module.scss
@@ -207,6 +207,10 @@
   [class*="link_hds-link"] {
     --link-visited-color: var(--color-black);
     --link-color: var(--color-black);
+    font-weight: 600;
+    font-size: var(--fontsize-body-s);
+    line-height: var(--lineheight-s);
+    border: 8px solid transparent;
   }
 }
 


### PR DESCRIPTION
Changes for breadcrumbs. HDS link has build in span. Removed extra span. 

Test also the breadcrumb

the the appearance shouldn’t have changed
The text should be black with any hover effect
The pointer should be pointer as in other links.
Next.js you should not have any changes
Go to Drupal and some article
Navigate back to Current matter page
Drupal parent page url should go to this page.