### PR TITLE
THF-319: fix accordion margin

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -27,9 +27,10 @@ interface ContentMapperProps {
   locationId?: string | null,
   langcode?: string,
   sidebar?: NavProps,
+  className?: string,
 }
 
-export function ContentMapper({ content, pageType, locationId, mapId, langcode,  sidebar, ...props }: ContentMapperProps): JSX.Element {
+export function ContentMapper({ content, pageType, locationId, mapId, langcode,  sidebar, className, ...props }: ContentMapperProps): JSX.Element {
 
   return content.map((item: any) => {
     const { type, id } = item
@@ -41,7 +42,7 @@ export function ContentMapper({ content, pageType, locationId, mapId, langcode, 
           return null
         }
         return (
-          <div className='component' key={key}>
+          <div className={`component ${className}`} key={key}>
             <Container className='container'>
               <HtmlBlock {...item} key={key} />
             </Container>

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -92,7 +92,7 @@ function Accordion(props: AccordionProps): JSX.Element {
                 }}
                 language={locale}>
                 {field_accordion_item_content?.length > 0 && (
-                  <ContentMapper content={field_accordion_item_content} />
+                  <ContentMapper content={field_accordion_item_content} className={'accordion_component'} />
                 )}
               </HDSAccordion>
             ) : (
@@ -102,7 +102,7 @@ function Accordion(props: AccordionProps): JSX.Element {
                 index={i + 1}
                 field_accordion_item_heading={field_accordion_item_heading}>
                 {field_accordion_item_content?.length > 0 && (
-                  <ContentMapper content={field_accordion_item_content} />
+                  <ContentMapper content={field_accordion_item_content} className={'accordion_component'}/>
                 )}
               </NumberedAccordion>
             )

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -209,6 +209,11 @@ h5, .h5,
   order: -1;
 }
 
+.accordion_component {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
 .content-region {
   .component {
     margin-top: var(--spacing-4-xl);


### PR DESCRIPTION
Accordion element html text had unwanted margins. Added new class from accordion component as props which is passed to contentMapper to over writing the margins from component css class. 

How to test: 

- Go to test page: https://tyollisyyspalvelut-ui.test.hel.ninja/accordion-testi
- Create basic page on local and add same components 
- The accordion shouldn’t have big margin 
- Other components should look exactly same