### PR TITLE
THF-488: Newsletter page and listing element changes

### DIFF
--- a/pages/api/news.ts
+++ b/pages/api/news.ts
@@ -10,9 +10,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
 
-  const { limit, locale }:any = req?.query
+  const { limit, filter, locale }:any = req?.query
 
-  news = await getNews(limit, locale).catch((e) => {
+  news = await getNews(limit, filter, locale).catch((e) => {
     console.log('Error fetching news from Drupal: ', e)
     throw e
   })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -58,6 +58,10 @@
     "cancelled_text": "Cancelled",
     "field_offers_info_url": "Sign up"
   },
+  "news": {
+    "news": "News",
+    "newsletter": "Newsletter"
+  },
   "video": {
     "cookie_consent": "You have not allowed the use of cookies on this site.",
     "link_text": "Please accept cookies to see the content."

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -58,6 +58,10 @@
     "cancelled_text": "Peruttu",
     "field_offers_info_url": "Ilmoittaudu"
   },
+  "news": {
+    "news": "Uutinen",
+    "newsletter": "Uutiskirje"
+  },
   "video": {
     "cookie_consent": "Et ole antanut lupaa asettaa evästeitä.",
     "link_text": "Hyväksythän evästeet nähdäksesi sisällön"

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -58,6 +58,10 @@
     "cancelled_text": "Inställt",
     "field_offers_info_url": "Bli Medlem"
   },
+  "news": {
+    "news": "Nyhet",
+    "newsletter": "Nyhetsbrev"
+  },
   "video": {
     "cookie_consent": "Du har inte gett tillstånd att installera cookies.",
     "link_text": "Godkänn cookies för att se innehållet."

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -13,6 +13,7 @@ import styles from './news.module.scss'
 interface NewsListProps {
   field_title: string;
   field_short_list: boolean;
+  field_news_filter: string,
   field_news_list_desc: DrupalFormattedText;
   langcode: string;
   field_background_color: {
@@ -24,6 +25,7 @@ interface News {
   path: Path,
   title: string,
   status: boolean,
+  field_article_category: string,
 }
 
 interface Path {
@@ -36,6 +38,7 @@ function NewsList({
   field_title,
   field_short_list,
   field_news_list_desc,
+  field_news_filter,
   langcode,
   field_background_color,
 }: NewsListProps): JSX.Element {
@@ -43,7 +46,7 @@ function NewsList({
   const [newsIndex, setNewsIndex] = useState<number>(1)
   const [paginatedNews, setPaginatedNews] = useState<Node[]>([])
   const bgColor = field_background_color?.field_css_name || 'white'
-  const fetcher = () => getNews(field_short_list, langcode)
+  const fetcher = () => getNews(field_short_list, field_news_filter, langcode)
   const { data: news, error } = useSWR(`/news`, fetcher)
 
   const total: number = (news && news.length) || 0
@@ -61,7 +64,7 @@ function NewsList({
       className='component'
       style={{ backgroundColor: `var(--color-${bgColor})` }}>
       <Container className='container'>
-        <div className={styles.newsListTitleArea}>
+        <div className={styles.newsListTitleArea}>          
           {field_title && <h2>{field_title}</h2>}
           {field_short_list && (
             <a href={t('list.news_url')}>
@@ -82,6 +85,9 @@ function NewsList({
                 <a href={getPathAlias(news.path)}>
                   <h3 className={styles.newsTitle}>{news.title}</h3>
                 </a>
+                {news.field_article_category === 'newsletter' && (
+                  <p>{ t('news.newsletter') }</p>
+                )}
                 {news.published_at && (
                   <p className={styles.articleDate}>
                     <time dateTime={news.published_at}>{`${dateformat(

--- a/src/components/news/news.module.scss
+++ b/src/components/news/news.module.scss
@@ -41,7 +41,7 @@
   flex-grow: 1;
   border-left: 0.5rem solid var(--color-metro);
   padding: 0 0 0 var(--spacing-s);
-  height: var(--spacing-layout-xl);
+  min-height: var(--spacing-layout-xl);
   overflow:hidden;
   word-wrap: break-word;
   width: 100%;

--- a/src/components/pageTemplates/NodeArticlePage.tsx
+++ b/src/components/pageTemplates/NodeArticlePage.tsx
@@ -1,5 +1,6 @@
 import { Container } from 'hds-react'
 import { Node } from '@/lib/types'
+import { useTranslation } from 'next-i18next'
 import dateformat from 'dateformat'
 import ContentMapper from '@/components/ContentMapper'
 
@@ -10,14 +11,18 @@ interface NodeArticlePageProps {
 }
 
 export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.Element {
-  const { title, field_lead, created, field_content, langcode, published_at } = node;
+  const { title, field_lead, field_article_category, created, field_content, langcode, published_at } = node;
   const articleDate = published_at !== null ? published_at : created;
+  const { t } = useTranslation();
 
   return (
     <article>
       <Container className="container content-region">
         <div className={styles.newsArticle}>
           <h1>{title}</h1>
+          {field_article_category === 'newsletter' && (
+            <p className={styles.articleType}>{ t('news.newsletter') }</p>
+          )}
           {field_lead && (
             <div className='lead-in'>{field_lead}</div>
           )}

--- a/src/components/pageTemplates/articlePage.module.scss
+++ b/src/components/pageTemplates/articlePage.module.scss
@@ -19,3 +19,8 @@
   color: var(--color-black-60);
   font-size: var(--fontsize-body-m);
 }
+
+.articleType {
+  font-size: var(--fontsize-body-xl);
+  font-weight: bold;
+}

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -30,8 +30,8 @@ export const getEventsSearch = async (eventsIndex: number, filter: string | null
   return data
 }
 
-export const getNews = async (shortList: boolean, locale: Locale) => {
-  const { data } = await axios(`${NEWS_URL}`, { params: { limit: shortList, locale: locale } })
+export const getNews = async (shortList: boolean, newsFilter: string, locale: Locale) => {
+  const { data } = await axios(`${NEWS_URL}`, { params: { limit: shortList, filter: newsFilter, locale: locale } })
   return data
 }
 

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -140,6 +140,7 @@ const getLandingPageQueryParams = () =>
     .addFields(CONTENT_TYPES.NEWS_LIST, [
       'field_title',
       'field_short_list',
+      'field_news_filter',
       'field_news_list_desc',
       'field_background_color',
     ])
@@ -193,6 +194,7 @@ export const baseArticlePageQueryParams = () =>
       'langcode',
       'field_lead',
       'field_content',
+      'field_article_category',
       'status',
       'published_at',
     ])

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,7 +25,8 @@ export interface Node extends DrupalNode {
   picture_url: string;
   picture_url_override: any;
   drupal_internal__id: string;
-  field_hide_navigation: boolean;
+  field_hide_navigation?: boolean;
+  field_article_category?: string;
 }
 
 type TextFormats = 'basic_html' | 'restricted_html' | 'plain_text'


### PR DESCRIPTION
This PR:
- Adds an article type filter to the api
- Changes news list to use the article type filter if one is set
- Adds "newsletter" tag to articles if depending on the type
- Modifies news list styles so longer titles fit the boxes

**To test**
- Checkout and install this branch for the Drupal side: https://github.com/City-of-Helsinki/drupal-employment-services/pull/140
- Checkout branch, run `yarn dev`
- While testing the Drupal changes, make sure the "newsletter / uutiskirje / nyhetsbrev" tag is visible on both article lists and article pages if the article is a newsletter (the string should be translated to english, finnish and swedish)
- Read code changes