### PR TITLE
Thf 551 breadcrumbs path focus

### DIFF
--- a/src/components/navigation/navigation.module.scss
+++ b/src/components/navigation/navigation.module.scss
@@ -194,7 +194,7 @@
   align-self: stretch;
   align-items: center;
   display: flex;
-  line-height: 0;
+  line-height: 2;
   outline: none;
   padding: var(--spacing-3-xs) 0;
   span {


### PR DESCRIPTION
Fixed breadcrumbs path focus. 


How to test:
- go to page which have breadcrumbs example http://localhost:3000/en/contact-information/phone-services
- press one of the breadcrumb link
- you should see blue border when the link has focus