### PR TITLE
THF-566: correct footer, cookies and redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -574,13 +574,13 @@ const nextConfig = {
       },
       {
         source: '/so',
-        destination: 'so/frontpage',
+        destination: '/so/frontpage',
         permanent: true,
         locale: false,
       },
       {
         source: '/ru',
-        destination: 'ru/frontpage',
+        destination: '/ru/frontpage',
         permanent: true,
         locale: false,
       },

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,6 +7,8 @@ import Link from '@/components/link/Link'
 import getMenu from '@/lib/get-menu'
 import { Layout } from '@/components/layout/Layout'
 import { NavProps, FooterProps } from '@/lib/types'
+import { getDrupalClient } from '@/lib/drupal-client'
+import { primaryLanguages } from '@/lib/helpers'
 
 const notFoundTexts = {
   fi: {
@@ -26,12 +28,37 @@ interface PageNotFoundProps {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
+  const drupal = getDrupalClient();
   const { locale, defaultLocale } = context as { locale: Locale, defaultLocale: Locale }
 
   const langLinks = { fi: '/', en: '/en', sv: '/sv'}
-  const { tree: menu } = await getMenu('main', locale, defaultLocale)
-  const { tree: themes } = await getMenu('additional-languages', locale, defaultLocale)
-  const { tree: footerNav } = await getMenu('footer', locale, defaultLocale)
+  const { tree: menu } = await drupal.getMenu('main', {
+    locale: locale,
+    defaultLocale: defaultLocale,
+  });
+  const { tree: themes } = await drupal.getMenu('additional-languages', {
+    locale: locale,
+    defaultLocale: defaultLocale,
+  });
+
+  const getFooterMenu = () => {
+    if (primaryLanguages.includes(locale)) {
+      return 'footer'
+    } else {
+      return 'footer-other-languages'; 
+    }
+  }
+  const getFooterMenuLang = () => {
+    if (primaryLanguages.includes(locale)) {
+      return locale;
+    } else {
+      return 'en'; 
+    }
+  }
+  const { tree: footerNav } = await drupal.getMenu(getFooterMenu(), {
+    locale: getFooterMenuLang(),
+    defaultLocale: defaultLocale,
+  });
 
   return {
     props: {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -177,7 +177,8 @@ export async function getStaticProps(
     menuItems,
     getPathAlias(node?.path),
     node?.title,
-    node?.type
+    node?.type,
+    locale
   );
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ interface HomePageProps {
 export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<HomePageProps>> {
   const { locale, defaultLocale } = context as { locale: Locale, defaultLocale: Locale }
   const { REVALIDATE_TIME, DRUPAL_FRONT_PAGE } = getConfig().serverRuntimeConfig
-  const drupal = getDrupalClient()
+  const drupal = getDrupalClient();
 
   const node = await drupal.getResourceByPath<Node>(DRUPAL_FRONT_PAGE, {
     locale,
@@ -45,9 +45,18 @@ export async function getStaticProps(context: GetStaticPropsContext): Promise<Ge
   }
 
   const langLinks = { fi: '/', en: '/en', sv: '/sv'}
-  const { tree: menu } = await getMenu('main', locale, defaultLocale)
-  const { tree: themes } = await getMenu('additional-languages', locale, defaultLocale)
-  const { tree: footerNav } = await getMenu('footer', locale, defaultLocale)
+  const { tree: menu } = await drupal.getMenu('main', {
+    locale,
+    defaultLocale,
+  });
+  const { tree: themes } = await drupal.getMenu('additional-languages', {
+    locale,
+    defaultLocale,
+  });
+  const { tree: footerNav } = await drupal.getMenu('footer', {
+    locale,
+    defaultLocale,
+  });
 
   return {
     props: {

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -81,18 +81,6 @@
   padding-bottom:  var(--spacing-2-xs);
 }
 
-.selected {
-  background-color: var(--color-fog-medium-light) !important;
-  border: none !important;
-  color: var(--color-black-90) !important;
-  margin-right: var(--spacing-xs);
-  margin-bottom: var(--spacing-s);
-  width: auto;
-
-  span:first-letter {
-    text-transform: capitalize;
-  }
-}
 
 .supplementary {
   --background-color-hover: var(--color-black-90) !important;  
@@ -143,6 +131,19 @@
     margin-bottom: var(--spacing-s);
     width: auto;
 
+    span:first-letter {
+      text-transform: capitalize;
+    }
+  }
+  
+  .selected {
+    background-color: var(--color-fog-medium-light) !important;
+    border: none !important;
+    color: var(--color-black-90) !important;
+    margin-right: var(--spacing-xs);
+    margin-bottom: var(--spacing-s);
+    width: auto;
+  
     span:first-letter {
       text-transform: capitalize;
     }

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -6,6 +6,7 @@ import { DrupalMenuLinkContent } from 'next-drupal';
 import { FooterProps } from '@/lib/types';
 
 import styles from './navigation.module.scss';
+import { primaryLanguages } from '@/lib/helpers';
 
 function Footer(props: FooterProps): JSX.Element {
   const { t } = useTranslation();
@@ -45,7 +46,7 @@ function Footer(props: FooterProps): JSX.Element {
         {renderFooterNav(footerNav)}
         <HDSFooter.SoMe>
           <HDSFooter.Item
-            icon={<IconFacebook size="m" aria-label={facebook}/>}
+            icon={<IconFacebook size="m" aria-label={facebook} />}
             href="https://www.facebook.com/HelsinginTyollisyyspalvelut"
           />
           <HDSFooter.Item
@@ -53,7 +54,7 @@ function Footer(props: FooterProps): JSX.Element {
             href="https://www.instagram.com/helsingintyollisyyspalvelut"
           />
           <HDSFooter.Item
-            icon={<IconLinkedin size="m" aria-label={linkedIn}/>}
+            icon={<IconLinkedin size="m" aria-label={linkedIn} />}
             href="https://www.linkedin.com/showcase/helsingintyollisyyspalvelut"
           />
         </HDSFooter.SoMe>
@@ -65,7 +66,13 @@ function Footer(props: FooterProps): JSX.Element {
           label={t('footer.accessibility')}
         />
         <HDSFooter.Item
-          href={locale === 'fi' ? '/cookies' : `/${locale}/cookies`}
+          href={
+            locale === 'fi'
+              ? '/cookies'
+              : primaryLanguages.includes(locale)
+              ? `/${locale}/cookies`
+              : '/en/cookies'
+          }
           label={t('footer.cookie_settings')}
         />
         <HDSFooter.Item

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -14,6 +14,7 @@ interface newPage {
   title: string; 
   url: string;
   parent: string;
+  locale: string;
 }
 
 export const eventTags = [
@@ -103,7 +104,8 @@ export const getBreadCrumb = (
   menuItems: DrupalMenuLinkContent[],
   path: string,
   title: string,
-  type: string
+  type: string,
+  locale: string,
 ): BreadcrumbContent[] => {
   const page = menuItems.find(({ url }) => url === path);
 
@@ -118,11 +120,14 @@ export const getBreadCrumb = (
     title: title,
     url: path,
     parent: '',
+    locale: locale,
   };
-
   // Pages that are not in menus always get a breadcrumb.
   if (!page) {
-    if (type !== 'node--event' && type !== 'node--article') {
+    if (
+      (type !== 'node--event' && type !== 'node--article') ||
+      (type === 'node--article' && !primaryLanguages.includes(locale))
+    ) {
       return [newPage];
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,7 @@ export interface BreadcrumbContent {
   id: string;
   title: string;
   url: string;
+  locale?: string;
 }
 
 export interface Tags {


### PR DESCRIPTION
Fixed footer problems when getting to 404 page and fixed footer cookies problems. Also fixed redirect to ru and so frontpages.

How to test:
- When changing to this branch -->  restart next if you local environment is on.
- Try url http://localhost:3000/ru and http://localhost:3000/so
-> You should get yourself onto ru and so front pages
- Stay on the last front page.
- See that the footer has cookies url en/cookies
- Write to the browser's url place example http://localhost:3000/ru/helloworld (page that doesn't exist)
- the 404 page should have en footer example en/about rather than node/4567 and all the footer links should work.