### PR TITLE
THF-482: Disable filter tags if the adding tag doesn't get results.

### DIFF
--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -23,7 +23,7 @@ export default async function handler(
     aggs: {
       events_tags: {
         terms: {
-          field: 'field_event_tags.keyword',
+          field: 'field_event_tags',
           size: 100,
         },
       },

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -1,11 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as Elastic from '@/lib/elasticsearch';
 
-type Data = any;
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data>
+  res: NextApiResponse<any>
 ) {
   const { locale }: any = req?.query || {};
 
@@ -24,7 +23,7 @@ export default async function handler(
     aggs: {
       events_tags: {
         terms: {
-          field: 'field_event_tags',
+          field: 'field_event_tags.keyword',
           size: 100,
         },
       },

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -36,6 +36,18 @@ const getTotal = (data: EventData[]) => {
   };
 };
 
+const getAvailableTag = (events: any) => {
+  const availableTags: string[] = [];
+  events
+    ?.map((event: { field_event_tags: string[] }) => event?.field_event_tags)
+    .forEach((field_event_tag: string[]) =>
+      field_event_tag?.forEach((tag: string) =>
+        !availableTags.includes(tag) ? availableTags.push(tag) : null
+      )
+    );
+  return availableTags;
+};
+
 export default function Events(props: EventListProps): JSX.Element {
   const { field_title, field_events_list_desc } = props;
   const { t } = useTranslation();
@@ -76,15 +88,6 @@ export default function Events(props: EventListProps): JSX.Element {
     setSize(1);
   }, [filter, setSize, updateTags]);
 
-  const availableTags: string[] = [];
-  events
-    ?.map((event: { field_event_tags: string[] }) => event?.field_event_tags)
-    .forEach((field_event_tag: string[]) =>
-      field_event_tag?.forEach((tag: string) =>
-        !availableTags.includes(tag) ? availableTags.push(tag) : null
-      )
-    );
-
   return (
     <div className="component">
       <Container className="container">
@@ -107,7 +110,7 @@ export default function Events(props: EventListProps): JSX.Element {
             {eventsTags &&
               eventsTags?.map((tag: string, i: number) => (
                 <HDSButton
-                  disabled={!availableTags.includes(tag)}
+                  disabled={!getAvailableTag(events).includes(tag)}
                   role="checkbox"
                   aria-checked={filter.includes(tag)}
                   aria-label={`${t('search.filter')} ${tag.replace('_', ' ')}`}

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -136,9 +136,7 @@
   }
 
   .selected {
-    background-color: var(--color-fog-medium-light) !important;
     border: none !important;
-    color: var(--color-black-90) !important;
     margin-right: var(--spacing-xs);
     margin-bottom: var(--spacing-s);
     width: auto;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -2,14 +2,12 @@ import { DrupalMenuLinkContent } from 'next-drupal';
 import { GroupingProps, Node } from '@/lib/types';
 import getConfig from 'next/config';
 
-import { i18n } from 'next-i18next.config';
-
 import { BreadcrumbContent } from './types';
 import { NODE_TYPES } from '@/lib/drupalApiTypes';
 import { NextApiResponse } from 'next';
 
 
-interface newPage {
+interface NewPage {
   id: string;
   title: string; 
   url: string;
@@ -115,7 +113,7 @@ export const getBreadCrumb = (
   }
 
   // Breadcrumb object for pages without menu attachment
-  let newPage: newPage = {
+  let newPage: NewPage = {
     id: 'current_page_crumb',
     title: title,
     url: path,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,13 @@ export interface EventState {
   events: EventData[]
 }
 
+export interface EventData  {
+  events: EventData[];
+  tags: string[];
+  total: number;
+  maxTotal?: number;
+}
+
 export interface EventListProps {
   pageType?: string
   field_title: string


### PR DESCRIPTION
Added tag disabling if adding the tag wont bring result.

How to test:

- Filter events on page http://localhost:3000/en/current-matters/events
- Choose filter Recruitment of employees you should get few options.
- You should now only have filter Remote event available. Other should be disabled. 
- Try other filter tags as well. 
- Also see that the logic still works. Choose example tag Recruitment of employees and then Remote event. You should only get the events which have both tags.