### PR TITLE
Thf 572 scheduler UI

### DIFF
--- a/src/components/pageTemplates/NodeArticlePage.tsx
+++ b/src/components/pageTemplates/NodeArticlePage.tsx
@@ -1,19 +1,31 @@
-import { Container } from 'hds-react'
-import { Node } from '@/lib/types'
-import { useTranslation } from 'next-i18next'
-import dateformat from 'dateformat'
-import ContentMapper from '@/components/ContentMapper'
+import { Container } from 'hds-react';
+import { Node } from '@/lib/types';
+import { useTranslation } from 'next-i18next';
+import dateformat from 'dateformat';
+import ContentMapper from '@/components/ContentMapper';
 
-import styles from './articlePage.module.scss'
+import styles from './articlePage.module.scss';
 
 interface NodeArticlePageProps {
-  node: Node
+  node: Node;
 }
 
-export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.Element {
-  const { title, field_lead, field_article_category, created, field_content, langcode, published_at } = node;
-  const articleDate = published_at !== null ? published_at : created;
-  const { t } = useTranslation();
+export function NodeArticlePage({
+  node,
+  ...props
+}: NodeArticlePageProps): JSX.Element {
+  const {
+    title,
+    field_lead,
+    field_article_category,
+    created,
+    field_content,
+    langcode,
+    published_at,
+  } = node;
+  const articleDate =
+    published_at !== null && published_at > created ? published_at : created;
+  const { t } = useTranslation();  
 
   return (
     <article>
@@ -21,20 +33,25 @@ export function NodeArticlePage({ node, ...props }: NodeArticlePageProps): JSX.E
         <div className={styles.newsArticle}>
           <h1>{title}</h1>
           {field_article_category === 'newsletter' && (
-            <p className={styles.articleType}>{ t('news.newsletter') }</p>
+            <p className={styles.articleType}>{t('news.newsletter')}</p>
           )}
-          {field_lead && (
-            <div className='lead-in'>{field_lead}</div>
-          )}
+          {field_lead && <div className="lead-in">{field_lead}</div>}
           <div className={styles.pageDivider}></div>
-          { articleDate && <p className={styles.articleDate}><time dateTime={articleDate}>{`${dateformat(articleDate, 'dd.mm.yyyy')}`}</time></p>}
+          {articleDate && (
+            <p className={styles.articleDate}>
+              <time dateTime={articleDate}>{`${dateformat(
+                articleDate,
+                'dd.mm.yyyy'
+              )}`}</time>
+            </p>
+          )}
           {field_content?.length > 0 && (
             <ContentMapper content={node.field_content} langcode={langcode} />
           )}
         </div>
       </Container>
     </article>
-  )
+  );
 }
 
-export default NodeArticlePage
+export default NodeArticlePage;


### PR DESCRIPTION
When scheduler is used created time will change and publish_at time will stay the same. If we don't use scheduler then we want to see publish_at time.

How to test:
- Test this branch with Drupal back end from this branch https://github.com/City-of-Helsinki/drupal-employment-services/pull/144
- Follow the instructions in the Drupal branch.
- On file src/components/pageTemplates/NodeArticlePage.tsx
- To row 29 put` console.log('node-->', node)`  
-  To row 30 put 
```
const test =
    published_at !== null && published_at > created ? 'published_at' : 'created';
```
-  To row 40 put `<p>{test}</p>` .
-  Then create an article page and publish it.
-  You should see with on the page published_at text.
-  Then create a new article page and schedule it to be published 2 min later.
-  Wait 3 min and run cron run from https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/config/system/cron
-  You should now see the created on the page.