### PR TITLE
Thf 535 super event UI

### DIFF
--- a/pages/api/related-events.ts
+++ b/pages/api/related-events.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getRelatedEvents } from '@/lib/ssr-api';
+import qs from 'qs';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const query: Partial<{
+    [key: string]: string | string[];
+  }> = req?.query;
+
+  const queryParams: any = qs.parse(query as string | Record<string, string>);
+  const events = await getRelatedEvents(queryParams).catch((e) => {
+    console.log('Error fetching events from Drupal: ', e);
+    throw e;
+  });
+
+  // No posts allowed, no missing params-errors revealed.
+  if (req.method !== 'GET') {
+    res.status(400).json(events);
+    return;
+  }
+
+  res.status(200).json(events);
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -64,7 +64,8 @@
     "provider": "Organizer information",
     "publisher": "Publisher information",
     "showAll": "Show All",
-    "showLess": "Hide"
+    "showLess": "Hide",
+    "Other_times": "Other times of the event"
   },
   "news": {
     "news": "News",
@@ -102,6 +103,9 @@
     "title": "Feedback buttons cannot be displayed",
     "text": "To use this feature, you must accept cookies from the site. You can provide feedback on this page by enabling statistics-related cookies.",
     "button": "Change cookie settings"
+  },
+  "datetime": {
+    "time": "at"
   },
   "Sun": "Sun",
   "Mon": "Mon",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -62,7 +62,9 @@
     "cancelled_text": "Cancelled",
     "field_offers_info_url": "Sign up",
     "provider": "Organizer information",
-    "publisher": "Publisher information"
+    "publisher": "Publisher information",
+    "showAll": "Show All",
+    "showLess": "Hide"
   },
   "news": {
     "news": "News",
@@ -100,5 +102,12 @@
     "title": "Feedback buttons cannot be displayed",
     "text": "To use this feature, you must accept cookies from the site. You can provide feedback on this page by enabling statistics-related cookies.",
     "button": "Change cookie settings"
-  }
+  },
+  "Sun": "Sun",
+  "Mon": "Mon",
+  "Tue": "Tue",
+  "Wed": "Wed",
+  "Thu": "Thu",
+  "Fri": "Fri",
+  "Sat": "Sat"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -62,7 +62,9 @@
     "cancelled_text": "Peruttu",
     "field_offers_info_url": "Ilmoittaudu",
     "provider": "Järjestäjän tiedot",
-    "publisher": "Julkaisijan tiedot"
+    "publisher": "Julkaisijan tiedot",
+    "showAll": "Näytä kaikki",
+    "showLess": "Piilota",
   },
   "news": {
     "news": "Uutinen",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -65,6 +65,7 @@
     "publisher": "Julkaisijan tiedot",
     "showAll": "Näytä kaikki",
     "showLess": "Piilota",
+    "Other_times": "Tapahtuman muut ajat"
   },
   "news": {
     "news": "Uutinen",
@@ -102,6 +103,9 @@
     "title": "Sivun palautenappeja ei voida näyttää",
     "text": "Toiminnon käyttämiseksi vaaditaan, että hyväksyt sivuston evästeet. Pääset antamaan palautetta tästä sivusta sallimalla evästeasetuksista tilastointiin liittyvät evästeet.",
     "button": "Muokkaa evästeasetuksia"
+  },
+  "datetime": {
+    "time": "kl."
   },
   "Sun": "Su",
   "Mon": "Ma",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -100,6 +100,12 @@
     "title": "Sivun palautenappeja ei voida näyttää",
     "text": "Toiminnon käyttämiseksi vaaditaan, että hyväksyt sivuston evästeet. Pääset antamaan palautetta tästä sivusta sallimalla evästeasetuksista tilastointiin liittyvät evästeet.",
     "button": "Muokkaa evästeasetuksia"
-  }
-
+  },
+  "Sun": "Su",
+  "Mon": "Ma",
+  "Tue": "Ti",
+  "Wed": "Ke",
+  "Thu": "To",
+  "Fri": "Pe",
+  "Sat": "La"
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -62,7 +62,9 @@
     "cancelled_text": "Inställt",
     "field_offers_info_url": "Bli Medlem",
     "provider": "Arrangör",
-    "publisher": "Utgivare"
+    "publisher": "Utgivare",
+    "showAll": "Visa Alt",
+    "showLess": "Dölj",
   },
   "news": {
     "news": "Nyhet",
@@ -100,5 +102,12 @@
     "title": "Feedbackknappar kan inte visas",
     "text": "För att använda denna funktion måste du acceptera cookies från webbplatsen. Du kan ge feedback på den här sidan genom att aktivera statistikrelaterade cookies.",
     "button": "Ändra inställningarna för cookies"
-  }
+  },
+  "Sun": "Sön",
+  "Mon": "Mån",
+  "Tue": "Tis",
+  "Wed": "Ons",
+  "Thu": "Tor",
+  "Fri": "Fre",
+  "Sat": "Lör"
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -65,6 +65,7 @@
     "publisher": "Utgivare",
     "showAll": "Visa Alt",
     "showLess": "Dölj",
+    "Other_times": "Andra evenemangstider"
   },
   "news": {
     "news": "Nyhet",

--- a/src/components/dateTime/DateTime.tsx
+++ b/src/components/dateTime/DateTime.tsx
@@ -1,7 +1,7 @@
 import dateformat from 'dateformat'
 import { IconCalendar, IconClock } from 'hds-react'
 
-import styles from './events.module.scss'
+import styles from './dateTime.module.scss'
 
 export interface DateTimeProps {
   startTime: number

--- a/src/components/dateTime/DateTimeSimple.tsx
+++ b/src/components/dateTime/DateTimeSimple.tsx
@@ -21,11 +21,11 @@ function DateTimeSimple(props: DateTimeProps): JSX.Element {
 
   return (
     <>
-      <div>
+      <div style={{ marginRight: '1.5rem' }}>
         {`${t(getStartDateOfWeek.toString())} ${dateformat(startDate, `dd.mm.yyyy`)}`}
         {!isSameDay &&
           ` - ${t(getEndDateOfWeek.toString())} ${dateformat(endDate, 'ddd dd.mm.yyyy')},`}
-        {` klo ${dateformat(startDate, 'HH:MM')} - ${dateformat(
+        {` ${t('datetime.time')} ${dateformat(startDate, 'HH:MM')} - ${dateformat(
           endDate,
           'HH:MM'
         )}`}

--- a/src/components/dateTime/DateTimeSimple.tsx
+++ b/src/components/dateTime/DateTimeSimple.tsx
@@ -22,9 +22,9 @@ function DateTimeSimple(props: DateTimeProps): JSX.Element {
   return (
     <>
       <div>
-        {`${t(getStartDateOfWeek)} ${dateformat(startDate, `dd.mm.yyyy`)}`}
+        {`${t(getStartDateOfWeek.toString())} ${dateformat(startDate, `dd.mm.yyyy`)}`}
         {!isSameDay &&
-          ` - ${t(getEndDateOfWeek)} ${dateformat(endDate, 'ddd dd.mm.yyyy')},`}
+          ` - ${t(getEndDateOfWeek.toString())} ${dateformat(endDate, 'ddd dd.mm.yyyy')},`}
         {` klo ${dateformat(startDate, 'HH:MM')} - ${dateformat(
           endDate,
           'HH:MM'

--- a/src/components/dateTime/DateTimeSimple.tsx
+++ b/src/components/dateTime/DateTimeSimple.tsx
@@ -1,0 +1,37 @@
+import dateformat from 'dateformat';
+import { useTranslation } from 'next-i18next';
+
+export interface DateTimeProps {
+  startTime: number;
+  endTime: number;
+}
+
+function DateTimeSimple(props: DateTimeProps): JSX.Element {
+  const { startTime, endTime } = props;
+  const { t } = useTranslation();
+  const startDate = new Date(Number(startTime));
+  const endDate = new Date(Number(endTime));
+
+  const isSameDay =
+    startDate.getFullYear() === endDate.getFullYear() &&
+    startDate.getMonth() === endDate.getMonth() &&
+    startDate.getDate() === endDate.getDate();
+  const getStartDateOfWeek = dateformat(startDate, `ddd`);
+  const getEndDateOfWeek = dateformat(startDate, `ddd`);
+
+  return (
+    <>
+      <div>
+        {`${t(getStartDateOfWeek)} ${dateformat(startDate, `dd.mm.yyyy`)}`}
+        {!isSameDay &&
+          ` - ${t(getEndDateOfWeek)} ${dateformat(endDate, 'ddd dd.mm.yyyy')},`}
+        {` klo ${dateformat(startDate, 'HH:MM')} - ${dateformat(
+          endDate,
+          'HH:MM'
+        )}`}
+      </div>
+    </>
+  );
+}
+
+export default DateTimeSimple;

--- a/src/components/dateTime/dateTime.module.scss
+++ b/src/components/dateTime/dateTime.module.scss
@@ -1,0 +1,14 @@
+.dateTime {
+    padding: 0;
+  
+    div {
+      display: flex;
+      font-size: var(--fontsize-body-m);
+      margin-top: var(--spacing-3-xs);
+      align-items: flex-end;
+    }
+  
+    svg {
+      margin-right: var(--spacing-xs);
+    }
+  }

--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -10,10 +10,10 @@ import { getPathAlias } from '@/lib/helpers';
 
 import HtmlBlock from '@/components/HtmlBlock';
 import TagList from './TagList';
-import DateTime from './DateTime';
-
 import styles from './events.module.scss';
 import EventStatus from './EventStatus';
+import DateTime from '../dateTime/DateTime';
+
 
 export function EventList({
   pageType,

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -13,11 +13,12 @@ import HtmlBlock from '../HtmlBlock';
 import Image from 'next/legacy/image';
 
 import styles from './events.module.scss';
-import DateTime from './DateTime';
+
 import TagList from './TagList';
 import EventStatus from './EventStatus';
 import { eventTags } from '@/lib/helpers';
 import { useCallback, useEffect, useState } from 'react';
+import DateTime from '../dateTime/DateTime';
 
 const getKey = (eventsIndex: number) => {
   return `${eventsIndex}`;

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -161,7 +161,7 @@ export default function Events(props: EventListProps): JSX.Element {
                   {event.field_image_url && (
                     <Image
                       src={event.field_image_url[0]}
-                      alt={event.field_image_alt[0]}
+                      alt={event.field_image_alt ? event.field_image_alt[0] : ''}
                       layout="responsive"
                       objectFit="cover"
                       width={3}

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import useSWR from 'swr';
-import { Button, Container, IconAngleDown, IconArrowRight } from 'hds-react';
+import { Button, Container, IconAngleDown, IconAngleUp, IconArrowRight } from 'hds-react';
 
 import { EventData, EventsRelatedQueryParams } from '@/lib/types';
 import { getRelatedEvents } from '@/lib/client-api';
@@ -25,7 +25,6 @@ export function RelatedEvents(props: DateTimeProps): JSX.Element {
     superEvent: props.superEvent,
     locale: locale,
   };
-  console.log(events);
 
   useEffect(() => {
     showAll ? setEventData(events) : setEventData(events?.slice(0, 3));
@@ -47,13 +46,13 @@ export function RelatedEvents(props: DateTimeProps): JSX.Element {
         ))}
         <Button
           variant="supplementary"
-          iconRight={<IconAngleDown />}
-          style={{ background: 'none', color: 'black' }}
+          iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
+          style={{ background: 'none', color: 'black', margin: 0, padding: 0 }}
           onClick={() => {
-            setShowAll(true);
+            setShowAll(!showAll);
           }}
         >
-          loadMoreText
+         {showAll ? t('event.showLess') : t('event.showAll')} 
         </Button>
       </Container>
     </div>

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -3,7 +3,13 @@ import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import useSWR from 'swr';
-import { Button, Container, IconAngleDown, IconAngleUp, IconArrowRight } from 'hds-react';
+import {
+  Button,
+  Container,
+  IconAngleDown,
+  IconAngleUp,
+  IconArrowRight,
+} from 'hds-react';
 
 import { EventData, EventsRelatedQueryParams } from '@/lib/types';
 import { getRelatedEvents } from '@/lib/client-api';
@@ -12,6 +18,7 @@ import styles from './events.module.scss';
 
 interface DateTimeProps {
   superEvent: string;
+  nodeId: string;
 }
 
 export function RelatedEvents(props: DateTimeProps): JSX.Element {
@@ -23,6 +30,7 @@ export function RelatedEvents(props: DateTimeProps): JSX.Element {
   const [eventData, setEventData] = useState<EventData[]>(events);
   const queryParams: EventsRelatedQueryParams = {
     superEvent: props.superEvent,
+    nodeId: props.nodeId,
     locale: locale,
   };
 
@@ -31,30 +39,36 @@ export function RelatedEvents(props: DateTimeProps): JSX.Element {
   }, [events, showAll]);
 
   return (
-    <div className="component hide-print">
-      <Container className="container">
-        {eventData?.map((event: EventData, i: number) => (
-          <div key={i} className={styles.relatedEvent}>
-            <Link href={event.path.alias} style={{ width: 'fit-content' }}>
-              <DateTimeSimple
-                startTime={event.field_start_time}
-                endTime={event.field_end_time}
-              />
-              <IconArrowRight size="s" aria-hidden />
-            </Link>
-          </div>
-        ))}
+    <Container className="container">
+      {eventData?.map((event: EventData, i: number) => (
+        <div key={i} className={styles.relatedEvent}>
+          <Link href={event.path.alias} style={{ width: 'fit-content' }}>
+            <DateTimeSimple
+              startTime={event.field_start_time}
+              endTime={event.field_end_time}
+            />
+            <IconArrowRight size="s" aria-hidden />
+          </Link>
+        </div>
+      ))}
+
+      {events?.length > 3 && (
         <Button
           variant="supplementary"
           iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
-          style={{ background: 'none', color: 'black', margin: 0, padding: 0 }}
+          style={{
+            background: 'none',
+            color: 'black',
+            margin: 0,
+            padding: 0,
+          }}
           onClick={() => {
             setShowAll(!showAll);
           }}
         >
-         {showAll ? t('event.showLess') : t('event.showAll')} 
+          {showAll ? t('event.showLess') : t('event.showAll')}
         </Button>
-      </Container>
-    </div>
+      )}
+    </Container>
   );
 }

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import useSWR from 'swr';
+import { Button, Container, IconAngleDown, IconArrowRight } from 'hds-react';
+
+import { EventData, EventsRelatedQueryParams } from '@/lib/types';
+import { getRelatedEvents } from '@/lib/client-api';
+import DateTimeSimple from '../dateTime/DateTimeSimple';
+import styles from './events.module.scss';
+
+interface DateTimeProps {
+  superEvent: string;
+}
+
+export function RelatedEvents(props: DateTimeProps): JSX.Element {
+  const fetcher = () => getRelatedEvents(queryParams);
+  const { data: events } = useSWR(`api/related-events`, fetcher);
+  const { t } = useTranslation();
+  const { locale } = useRouter();
+  const [showAll, setShowAll] = useState<boolean>(false);
+  const [eventData, setEventData] = useState<EventData[]>(events);
+  const queryParams: EventsRelatedQueryParams = {
+    superEvent: props.superEvent,
+    locale: locale,
+  };
+  console.log(events);
+
+  useEffect(() => {
+    showAll ? setEventData(events) : setEventData(events?.slice(0, 3));
+  }, [events, showAll]);
+
+  return (
+    <div className="component hide-print">
+      <Container className="container">
+        {eventData?.map((event: EventData, i: number) => (
+          <div key={i} className={styles.relatedEvent}>
+            <Link href={event.path.alias} style={{ width: 'fit-content' }}>
+              <DateTimeSimple
+                startTime={event.field_start_time}
+                endTime={event.field_end_time}
+              />
+              <IconArrowRight size="s" aria-hidden />
+            </Link>
+          </div>
+        ))}
+        <Button
+          variant="supplementary"
+          iconRight={<IconAngleDown />}
+          style={{ background: 'none', color: 'black' }}
+          onClick={() => {
+            setShowAll(true);
+          }}
+        >
+          loadMoreText
+        </Button>
+      </Container>
+    </div>
+  );
+}

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -183,6 +183,7 @@ ul.tags {
   max-width: 50rem;
   padding: var(--spacing-s);
   border-bottom: 1px solid var(--color-black-10);
+  position: relative;
   &:first-child {
     border-top: 1px solid var(--color-black-10);
   }
@@ -193,7 +194,9 @@ ul.tags {
     border: none;
   }
   svg {
-    margin-left: 3rem;
+    position: absolute;
+    margin-left: 20px;
+    right: 0;
   }
 }
 

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -168,21 +168,6 @@ ul.tags {
   }
 }
 
-.dateTime {
-  padding: 0;
-
-  div {
-    display: flex;
-    font-size: var(--fontsize-body-m);
-    margin-top: var(--spacing-3-xs);
-    align-items: flex-end;
-  }
-
-  svg {
-    margin-right: var(--spacing-xs);
-  }
-}
-
 .loadMore {
   display: flex;
   justify-content: center;
@@ -191,6 +176,24 @@ ul.tags {
   > button {
     --border-color-focus: var(--color-black-90);
     --border-color-hover-focus: var(--color-black-90);
+  }
+}
+
+.relatedEvent  {
+  max-width: 50rem;
+  padding: var(--spacing-s);
+  border-top: 1px solid var(--color-black-10);
+  &:last-child {
+    border-bottom: 1px solid var(--color-black-10);
+  }
+  a {
+    display: flex;
+    flex-flow: row wrap;
+    text-decoration: none;
+    border: none;
+  }
+  svg {
+    margin-left: 3rem;
   }
 }
 

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -182,9 +182,9 @@ ul.tags {
 .relatedEvent  {
   max-width: 50rem;
   padding: var(--spacing-s);
-  border-top: 1px solid var(--color-black-10);
-  &:last-child {
-    border-bottom: 1px solid var(--color-black-10);
+  border-bottom: 1px solid var(--color-black-10);
+  &:first-child {
+    border-top: 1px solid var(--color-black-10);
   }
   a {
     display: flex;

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -57,12 +57,9 @@ function NewsList({
 
   const total: number = news?.length ?? 0;
   useEffect(() => {
-    const filterNews = () => {
       const paginatedArticle = news?.slice(0, 4 * newsIndex);
       setPaginatedNews(paginatedArticle);
-    };
-    filterNews();
-  }, [news, newsIndex]); // eslint-disable-line
+  }, [news, newsIndex]);
 
   const loadMoreText = t('list.load_more');
   return (

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -8,6 +8,7 @@ import {
   IconAlertCircle,
   Button,
   IconFaceSmile,
+  IconCalendarPlus,
 } from 'hds-react';
 
 import { Node } from '@/lib/types';
@@ -19,7 +20,6 @@ import styles from './eventPage.module.scss';
 import EventStatus from '../events/EventStatus';
 import { RelatedEvents } from '../events/RelatedEvents';
 import DateTime from '../dateTime/DateTime';
-
 
 interface NodeEventPageProps {
   node: Node;
@@ -64,6 +64,9 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
   const onClick = () => {
     location.href = field_offers_info_url;
   };
+
+  console.log('node--->', node);
+
   return (
     <article>
       <Container className="container">
@@ -171,11 +174,24 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                     </div>
                   </div>
                 )}
+                {field_super_event && (
+                  <div>
+                    <h2 className={styles.location}>
+                      <IconCalendarPlus />
+                      <div className={styles.contentRegionSubHeader}>
+                        {t('event.Other_times')}
+                      </div>
+                    </h2>
+                    <RelatedEvents
+                      superEvent={field_super_event}
+                      nodeId={node.id}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           </div>
         </div>
-        {field_super_event && <RelatedEvents superEvent={field_super_event} />}
       </Container>
     </article>
   );

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -13,13 +13,17 @@ import {
 import { Node } from '@/lib/types';
 import HtmlBlock from '@/components/HtmlBlock';
 import TagList from '@/components/events/TagList';
-import DateTime from '@/components/events/DateTime';
+
 import Link from '@/components/link/Link';
 import styles from './eventPage.module.scss';
 import EventStatus from '../events/EventStatus';
+import { RelatedEvents } from '../events/RelatedEvents';
+import DateTime from '../dateTime/DateTime';
+
 
 interface NodeEventPageProps {
   node: Node;
+  superEvent: string;
 }
 
 interface ExternalLinks {
@@ -46,6 +50,7 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
     field_offers_info_url,
     field_event_tags,
     field_provider,
+    field_super_event,
   } = node;
 
   const { t } = useTranslation('common');
@@ -170,6 +175,7 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
             </div>
           </div>
         </div>
+        {field_super_event && <RelatedEvents superEvent={field_super_event} />}
       </Container>
     </article>
   );

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -1,13 +1,14 @@
 import axios from 'axios';
 import qs from 'qs';
 
-import { EventsQueryParams } from '@/lib/types';
+import { EventsQueryParams, EventsRelatedQueryParams } from '@/lib/types';
 import { Locale } from 'next-drupal';
 
 /** The Client API urls  */
 const EVENTS_URL = '/api/events';
 const EVENTS_SEARCH_URL = '/api/events-search';
 const EVENTS_TAGS_URL = '/api/events-tags';
+const RELATED_EVENTS = '/api/related-events'
 const NEWS_URL = '/api/news';
 const UNITS_URL = '/api/units';
 const SEARCH_URL = '/api/search';
@@ -37,6 +38,17 @@ export const getEventsSearch = async (
       return qs.stringify(params, { arrayFormat: 'repeat' });
     }, 
   });
+  return data;
+};
+
+export const getRelatedEvents = async (queryParams: EventsRelatedQueryParams) => {
+  const { data } = await axios(`${RELATED_EVENTS}`, {
+    params:
+      queryParams,
+      paramsSerializer: params => {
+        return qs.stringify(params, { arrayFormat: 'repeat' })
+      }
+  })
   return data;
 };
 

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -174,8 +174,8 @@ export const baseEventQueryParams = () =>
       'field_location_extra_info',
       'field_offers_info_url',
       'field_event_tags',
-      'field_publisher',
-      'field_provider'
+      'field_provider',
+      'field_super_event',
     ])
 
 const getEventPageQueryParams = () =>

--- a/src/lib/ssr-api.ts
+++ b/src/lib/ssr-api.ts
@@ -70,12 +70,13 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
 export const getRelatedEvents = async (
   queryParams: EventsRelatedQueryParams
 ) => {
-  const { superEvent } = queryParams;
+  const { superEvent, nodeId } = queryParams;
   const defaultLocale: Locale = 'fi';
   const locale: Locale = queryParams.locale ?? defaultLocale;
   const eventParams = () =>
     baseEventQueryParams()
       .addFilter('field_super_event', superEvent)
+      .addFilter('id', nodeId, 'NOT IN')
       .addSort('field_end_time', 'ASC')
       .addFilter('status', '1')
       .addFilter('langcode', locale);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,11 @@ export interface EventsQueryParams {
   locale?: Locale
 }
 
+export interface EventsRelatedQueryParams {
+  locale?: Locale;
+  superEvent: string;
+}
+
 export interface EventData {
   id: string;
   title: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,7 @@ export interface EventsQueryParams {
 export interface EventsRelatedQueryParams {
   locale?: Locale;
   superEvent: string;
+  nodeId: string;
 }
 
 export interface EventData {


### PR DESCRIPTION
### What has been done
- Brought a `super_event` field to ui. 
- Created new relates event component. 
- Crated new simple dateTime component and moved datetime component to their own folder,
- The component will show all event dates and times which have the same super_event field as the event you are on. It doesn't show the current event date and time on the list. 

#### How to test:
- test with branch `THF-535-super_event-field-to-drupal`
- Find an event that has super event and go to the page 
- You should have the new related events component right side of the page.
- If list has more than 3 event you'll see toggle button. 
- You can toggle the list up and down. 