### PR TITLE
THF-587: fix landing page accordion element

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -212,6 +212,8 @@ h5, .h5,
 .accordion_component {
   margin-top: 0 !important;
   margin-bottom: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }
 
 .content-region {


### PR DESCRIPTION
### Changes

Fixed landing page accordion element padding.


#### How to test
- Create a landing page with accordion element and check that the element don't have extra padding or margin in it. Compare to https://hds.hel.fi/components/accordion
- Check also that the change hasn't effect to accordion on basic page content type. Example http://localhost:3000/koulutus/opiskelu-tyottomana