### PR TITLE
THF-597: change layout

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -60,7 +60,9 @@
     "info_url_text": "Event homepage",
     "info_url_text_teams": "Open Teams-event",
     "cancelled_text": "Cancelled",
-    "field_offers_info_url": "Sign up"
+    "field_offers_info_url": "Sign up",
+    "provider": "Organizer information",
+    "publisher": "Publisher information"
   },
   "news": {
     "news": "News",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -60,7 +60,9 @@
     "info_url_text": "Tapahtuman kotisivut",
     "info_url_text_teams": "Avaa Teams-tapahtuma",
     "cancelled_text": "Peruttu",
-    "field_offers_info_url": "Ilmoittaudu"
+    "field_offers_info_url": "Ilmoittaudu",
+    "provider": "Järjestäjän tiedot",
+    "publisher": "Julkaisijan tiedot"
   },
   "news": {
     "news": "Uutinen",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -60,7 +60,9 @@
     "info_url_text": "Evenemangets hemsida",
     "info_url_text_teams": "Öppna Teams-evenemanget",
     "cancelled_text": "Inställt",
-    "field_offers_info_url": "Bli Medlem"
+    "field_offers_info_url": "Bli Medlem",
+    "provider": "Arrangör",
+    "publisher": "Utgivare"
   },
   "news": {
     "news": "Nyhet",

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -8,7 +8,6 @@ import {
   IconAlertCircle,
   Button,
   IconFaceSmile,
-  IconLayers,
 } from 'hds-react';
 
 import { Node } from '@/lib/types';
@@ -46,7 +45,6 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
     field_location_extra_info,
     field_offers_info_url,
     field_event_tags,
-    field_publisher,
     field_provider,
   } = node;
 
@@ -158,26 +156,13 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                 {field_provider && (
                   <div>
                     <h2 className={styles.location}>
-                      <IconLayers />
+                      <IconFaceSmile />
                       <div className={styles.contentRegionSubHeader}>
                         {t('event.provider')}
                       </div>
                     </h2>
                     <div className={styles.contentRegionText}>
                       {field_provider}
-                    </div>
-                  </div>
-                )}
-                {field_publisher && (
-                  <div>
-                    <div className={styles.location}>
-                      <IconFaceSmile />
-                      <h2 className={styles.contentRegionSubHeader}>
-                        {t('event.publisher')}
-                      </h2>
-                    </div>
-                    <div className={styles.contentRegionText}>
-                      {field_publisher}
                     </div>
                   </div>
                 )}

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -121,47 +121,68 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                     <div>{field_location_extra_info}</div>
                   </div>
                 )}
-                {field_publisher && (
-                  <div className={styles.location}>
-                    <IconFaceSmile />
-                    <div>{field_publisher}</div>
+              </div>
+            </div>
+            <div className={styles.eventDetailContainer}>
+              <div className={styles.contentRegionEventLeft}>
+                <div className={`${styles.contentContainer} content-region`}>
+                  {field_text?.processed && (
+                    <HtmlBlock field_text={field_text} />
+                  )}
+
+                  {field_info_url && (
+                    <Link href={field_info_url} text={infoUrlText} />
+                  )}
+                  {field_external_links.length > 0 &&
+                    field_external_links.map(
+                      (externalLink: ExternalLinks, key: number) => (
+                        <Link
+                          key={`${externalLink.title}-${key}`}
+                          href={externalLink.uri}
+                          text={externalLink.title}
+                        />
+                      )
+                    )}
+                </div>
+                {field_offers_info_url && (
+                  <Button
+                    onClick={onClick}
+                    theme="black"
+                    iconRight={<IconLinkExternal size="m" aria-hidden="true" />}
+                  >
+                    {t('event.field_offers_info_url')}
+                  </Button>
+                )}
+              </div>
+              <div className={styles.contentRegionEventRight}>
+                {field_provider && (
+                  <div>
+                    <h2 className={styles.location}>
+                      <IconLayers />
+                      <div className={styles.contentRegionSubHeader}>
+                        {t('event.provider')}
+                      </div>
+                    </h2>
+                    <div className={styles.contentRegionText}>
+                      {field_provider}
+                    </div>
                   </div>
                 )}
-
-                {field_provider && (
-                  <div className={styles.location}>
-                    <IconLayers />
-                    <div>{field_provider}</div>
+                {field_publisher && (
+                  <div>
+                    <div className={styles.location}>
+                      <IconFaceSmile />
+                      <h2 className={styles.contentRegionSubHeader}>
+                        {t('event.publisher')}
+                      </h2>
+                    </div>
+                    <div className={styles.contentRegionText}>
+                      {field_publisher}
+                    </div>
                   </div>
                 )}
               </div>
             </div>
-            <div className={`${styles.contentContainer} content-region`}>
-              {field_text?.processed && <HtmlBlock field_text={field_text} />}
-
-              {field_info_url && (
-                <Link href={field_info_url} text={infoUrlText} />
-              )}
-              {field_external_links.length > 0 &&
-                field_external_links.map(
-                  (externalLink: ExternalLinks, key: number) => (
-                    <Link
-                      key={`${externalLink.title}-${key}`}
-                      href={externalLink.uri}
-                      text={externalLink.title}
-                    />
-                  )
-                )}
-            </div>
-            {field_offers_info_url && (
-              <Button
-                onClick={onClick}
-                theme="black"
-                iconRight={<IconLinkExternal size="m" aria-hidden="true" />}
-              >
-                {t('event.field_offers_info_url')}
-              </Button>
-            )}
           </div>
         </div>
       </Container>

--- a/src/components/pageTemplates/eventPage.module.scss
+++ b/src/components/pageTemplates/eventPage.module.scss
@@ -16,6 +16,44 @@
   }
 }
 
+.eventDetailContainer {
+  display: flex;
+  flex-direction: column;
+  .location {
+    display: flex;
+    font-size: var(--fontsize-body-m);
+    margin-top: var(--spacing-2-xs);
+    
+    svg {
+      margin-right: var(--spacing-xs);
+    }
+
+    a svg {
+      vertical-align: bottom;
+      margin-left: var(--spacing-xs);
+      margin-right: 0;
+    }
+  }
+}
+
+.contentRegionEventLeft {
+  width: 100%;
+}
+
+.contentRegionEventRight {
+  padding: var(--spacing-m);
+}
+
+.contentRegionSubHeader {
+  font-size: var(--fontsize-body-l);
+  font-weight: 600;
+  margin: 0 0 var(--spacing-xs);
+}
+
+.contentRegionText {
+  margin-left: 2.2rem;
+}
+
 
 .headingContainer {
   padding: var(--spacing-s);
@@ -76,5 +114,15 @@
 
   .contentContainer {
     max-width: 50rem;
+  }
+}
+
+@media (min-width: $breakpoint-m) {
+  .eventDetailContainer {
+    display: flex;
+    flex-direction: row;
+  }
+  .contentRegionEventLeft {
+    width: 60%;
   }
 }


### PR DESCRIPTION
### Changes

Changed event page content layout. Layout has now 2 columns. The hero element's details content contains date and place fields. The other fields should now be placed in the right column of the content area. Below $breakpoint-m you get only 1 column and the detail are below the event description.

#### How to test

- Go to any event from event page http://localhost:3000/ajankohtaista/tapahtumat
- The Event should now have 2 columns
- Try also mobile and pad screen sizes. 
<img width="1114" alt="Screenshot 2023-09-04 at 14 01 15" src="https://github.com/City-of-Helsinki/employment-services-ui/assets/42113018/82996dd6-520d-4b43-80dd-081bb5525412">

 