### PR TITLE
Thf 601 nav languages and cookies

### DIFF
--- a/src/components/navigationComponents/LanguageSelect.tsx
+++ b/src/components/navigationComponents/LanguageSelect.tsx
@@ -73,7 +73,7 @@ function LanguageSelect({
               href={langLinks.ru}
               onClick={() => previewNavigation(langLinks.ru, preview)}
             >
-              hа русском
+              Русский
             </Link>
           )}
           {langLinks.so === activePath && activePath !== undefined && (
@@ -92,7 +92,7 @@ function LanguageSelect({
               href={langLinks.uk}
               onClick={() => previewNavigation(langLinks.uk, preview)}
             >
-              Українською
+              Українська мова
             </Link>
           )}
         </div>

--- a/src/components/navigationComponents/LanguageSelect.tsx
+++ b/src/components/navigationComponents/LanguageSelect.tsx
@@ -73,7 +73,7 @@ function LanguageSelect({
               href={langLinks.ru}
               onClick={() => previewNavigation(langLinks.ru, preview)}
             >
-              Russian
+              hа русском
             </Link>
           )}
           {langLinks.so === activePath && activePath !== undefined && (
@@ -82,7 +82,7 @@ function LanguageSelect({
               href={langLinks.so}
               onClick={() => previewNavigation(langLinks.so, preview)}
             >
-              Somali
+              Af-soomaaliga
             </Link>
           )}
 
@@ -92,7 +92,7 @@ function LanguageSelect({
               href={langLinks.uk}
               onClick={() => previewNavigation(langLinks.uk, preview)}
             >
-              Ukraine
+              Українською
             </Link>
           )}
         </div>

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -144,16 +144,16 @@ export const useReactAndShare = (
   lang: string | undefined,
   pageTitle: string | undefined
 ) => {
+    const [reactAndShareApiKey, setReactAndShareApiKey] = useState(getConfig().publicRuntimeConfig.REACT_AND_SHARE_EN)
   useEffect(() => {
     if (cookieConsent !== true) {
       return
     }
 
-    let reactAndShareApiKey = getConfig().publicRuntimeConfig.REACT_AND_SHARE_FI
-    if (lang === 'en') {
-      reactAndShareApiKey = getConfig().publicRuntimeConfig.REACT_AND_SHARE_EN
+    if (lang === 'fi') {
+      setReactAndShareApiKey(getConfig().publicRuntimeConfig.REACT_AND_SHARE_FI)
     } else if (lang === 'sv') {
-      reactAndShareApiKey = getConfig().publicRuntimeConfig.REACT_AND_SHARE_SV
+      setReactAndShareApiKey(getConfig().publicRuntimeConfig.REACT_AND_SHARE_SV)
     }
 
     const script = document.createElement("script")


### PR DESCRIPTION
### Changes

- Changes cookies api default key from Finnish to English
- Added other languages nav languages from english to origin language

#### Testing
- Check that the cookies work on en, fi and sv pages in those languages.
- Check example Russian page and see that the cookies are in English there as well.  