### PR TITLE
THF-604: fix relatedEvent and React and share

### DIFF
--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -106,7 +106,7 @@
     "button": "Muokkaa evästeasetuksia"
   },
   "datetime": {
-    "time": "kl."
+    "time": "klo"
   },
   "Sun": "Su",
   "Mon": "Ma",

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -22,17 +22,18 @@ interface DateTimeProps {
 }
 
 export default function RelatedEvents(props: DateTimeProps): JSX.Element {
-  const fetcher = () => getRelatedEvents(queryParams);
-  const { data: events } = useSWR(`api/related-events`, fetcher);
-  const { t } = useTranslation();
-  const { locale } = useRouter();
-  const [showAll, setShowAll] = useState<boolean>(false);
-  const [eventData, setEventData] = useState<EventData[]>(events);
+  const { locale, asPath } = useRouter();
   const queryParams: EventsRelatedQueryParams = {
     superEvent: props.superEvent,
     nodeId: props.nodeId,
     locale: locale,
   };
+  const fetcher = () => getRelatedEvents(queryParams);
+  const { data: events } = useSWR(`/${locale}/${asPath}`, fetcher);
+  const { t } = useTranslation();
+
+  const [showAll, setShowAll] = useState<boolean>(false);
+  const [eventData, setEventData] = useState<EventData[]>(events);
 
   useEffect(() => {
     showAll ? setEventData(events) : setEventData(events?.slice(0, 3));

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -9,6 +9,7 @@ import {
   IconAngleDown,
   IconAngleUp,
   IconArrowRight,
+  IconCalendarPlus,
 } from 'hds-react';
 
 import { EventData, EventsRelatedQueryParams } from '@/lib/types';
@@ -21,7 +22,9 @@ interface DateTimeProps {
   nodeId: string;
 }
 
-export default function RelatedEvents(props: DateTimeProps): JSX.Element {
+export default function RelatedEvents(
+  props: DateTimeProps
+): JSX.Element | null {
   const { locale, asPath } = useRouter();
   const queryParams: EventsRelatedQueryParams = {
     superEvent: props.superEvent,
@@ -39,37 +42,51 @@ export default function RelatedEvents(props: DateTimeProps): JSX.Element {
     showAll ? setEventData(events) : setEventData(events?.slice(0, 3));
   }, [events, showAll]);
 
-  return (
-    <Container className="container">
-      {eventData?.map((event: EventData, i: number) => (
-        <div key={i} className={styles.relatedEvent}>
-          <Link href={event.path.alias} style={{ width: 'fit-content' }}>
-            <DateTimeSimple
-              startTime={event.field_start_time}
-              endTime={event.field_end_time}
-            />
-            <IconArrowRight size="s" aria-hidden />
-          </Link>
+  if (events?.length > 0) {
+    return (
+      <div className={styles.contentRegionWrapper}>
+        <div className={styles.headerContent}>
+          <IconCalendarPlus />
+          <h2 className={styles.contentRegionSubHeader}>
+            {t('event.Other_times')}
+          </h2>
         </div>
-      ))}
+        <div className={styles.contentRegionText}>
+          <Container className="container">
+            {eventData?.map((event: EventData, i: number) => (
+              <div key={i} className={styles.relatedEvent}>
+                <Link href={event.path.alias} style={{ width: 'fit-content' }}>
+                  <DateTimeSimple
+                    startTime={event.field_start_time}
+                    endTime={event.field_end_time}
+                  />
+                  <IconArrowRight size="s" aria-hidden />
+                </Link>
+              </div>
+            ))}
 
-      {events?.length > 3 && (
-        <Button
-          variant="supplementary"
-          iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
-          style={{
-            background: 'none',
-            color: 'black',
-            margin: 0,
-            padding: 0,
-          }}
-          onClick={() => {
-            setShowAll(!showAll);
-          }}
-        >
-          {showAll ? t('event.showLess') : t('event.showAll')}
-        </Button>
-      )}
-    </Container>
-  );
+            {events?.length > 3 && (
+              <Button
+                variant="supplementary"
+                iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
+                style={{
+                  background: 'none',
+                  color: 'black',
+                  margin: 0,
+                  padding: 0,
+                }}
+                onClick={() => {
+                  setShowAll(!showAll);
+                }}
+              >
+                {showAll ? t('event.showLess') : t('event.showAll')}
+              </Button>
+            )}
+          </Container>
+        </div>
+      </div>
+    );
+  } else {
+    return null;
+  }
 }

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -16,6 +16,7 @@ import { EventData, EventsRelatedQueryParams } from '@/lib/types';
 import { getRelatedEvents } from '@/lib/client-api';
 import DateTimeSimple from '../dateTime/DateTimeSimple';
 import styles from './events.module.scss';
+import SideContent from '../sideContent/SideContent';
 
 interface DateTimeProps {
   superEvent: string;
@@ -44,47 +45,39 @@ export default function RelatedEvents(
 
   if (events?.length > 0) {
     return (
-      <div className={styles.contentRegionWrapper}>
-        <div className={styles.headerContent}>
-          <IconCalendarPlus />
-          <h2 className={styles.contentRegionSubHeader}>
-            {t('event.Other_times')}
-          </h2>
-        </div>
-        <div className={styles.contentRegionText}>
-          <Container className="container">
-            {eventData?.map((event: EventData, i: number) => (
-              <div key={i} className={styles.relatedEvent}>
-                <Link href={event.path.alias} style={{ width: 'fit-content' }}>
-                  <DateTimeSimple
-                    startTime={event.field_start_time}
-                    endTime={event.field_end_time}
-                  />
-                  <IconArrowRight size="s" aria-hidden />
-                </Link>
-              </div>
-            ))}
+      <SideContent header={t('event.Other_times')} icon={<IconCalendarPlus />}>
+        <Container className="container">
+          {eventData?.map((event: EventData, i: number) => (
+            <div key={i} className={styles.relatedEvent}>
+              <Link href={event.path.alias} style={{ width: 'fit-content' }}>
+                <DateTimeSimple
+                  startTime={event.field_start_time}
+                  endTime={event.field_end_time}
+                />
+                <IconArrowRight size="s" aria-hidden />
+              </Link>
+            </div>
+          ))}
 
-            {events?.length > 3 && (
-              <Button
-                variant="supplementary"
-                iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
-                style={{
-                  background: 'none',
-                  color: 'black',
-                  margin: 0,
-                  padding: 0,
-                }}
-                onClick={() => {
-                  setShowAll(!showAll);
-                }}
-              >
-                {showAll ? t('event.showLess') : t('event.showAll')}
-              </Button>
-            )}
-          </Container>
-        </div>
-      </div>
+          {events?.length > 3 && (
+            <Button
+              variant="supplementary"
+              iconRight={showAll ? <IconAngleUp /> : <IconAngleDown />}
+              style={{
+                background: 'none',
+                color: 'black',
+                margin: 0,
+                padding: 0,
+              }}
+              onClick={() => {
+                setShowAll(!showAll);
+              }}
+            >
+              {showAll ? t('event.showLess') : t('event.showAll')}
+            </Button>
+          )}
+        </Container>
+      </SideContent>
     );
   } else {
     return null;

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -223,3 +223,32 @@ ul.tags {
     flex-grow: 0;
   }
 }
+
+.contentRegionWrapper {
+  margin-bottom: var(--spacing-xl);
+}
+.headerContent {
+    display: flex;
+    font-size: var(--fontsize-body-m);
+    margin-top: var(--spacing-2-xs);
+    
+    svg {
+      margin-right: var(--spacing-xs);
+    }
+
+    a svg {
+      vertical-align: bottom;
+      margin-left: var(--spacing-xs);
+      margin-right: 0;
+    }
+  }
+
+  .contentRegionSubHeader {
+    font-size: var(--fontsize-body-l);
+    font-weight: 600;
+    margin: 0 0 var(--spacing-2-xs);
+  }
+  
+  .contentRegionText {
+    margin-left: 2.2rem;
+  }

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -223,32 +223,3 @@ ul.tags {
     flex-grow: 0;
   }
 }
-
-.contentRegionWrapper {
-  margin-bottom: var(--spacing-xl);
-}
-.headerContent {
-    display: flex;
-    font-size: var(--fontsize-body-m);
-    margin-top: var(--spacing-2-xs);
-    
-    svg {
-      margin-right: var(--spacing-xs);
-    }
-
-    a svg {
-      vertical-align: bottom;
-      margin-left: var(--spacing-xs);
-      margin-right: 0;
-    }
-  }
-
-  .contentRegionSubHeader {
-    font-size: var(--fontsize-body-l);
-    font-weight: 600;
-    margin: 0 0 var(--spacing-2-xs);
-  }
-  
-  .contentRegionText {
-    margin-left: 2.2rem;
-  }

--- a/src/components/navigationComponents/LanguageSelect.tsx
+++ b/src/components/navigationComponents/LanguageSelect.tsx
@@ -73,7 +73,7 @@ function LanguageSelect({
               href={langLinks.ru}
               onClick={() => previewNavigation(langLinks.ru, preview)}
             >
-              Русский
+              Россия
             </Link>
           )}
           {langLinks.so === activePath && activePath !== undefined && (
@@ -82,7 +82,7 @@ function LanguageSelect({
               href={langLinks.so}
               onClick={() => previewNavigation(langLinks.so, preview)}
             >
-              Af-soomaaliga
+              Soomaali
             </Link>
           )}
 
@@ -92,7 +92,7 @@ function LanguageSelect({
               href={langLinks.uk}
               onClick={() => previewNavigation(langLinks.uk, preview)}
             >
-              Українська мова
+              Україна
             </Link>
           )}
         </div>

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -9,7 +9,6 @@ import {
   Button,
   IconFaceSmile,
   IconGlobe,
-  IconCalendarPlus,
 } from 'hds-react';
 
 import { Node } from '@/lib/types';
@@ -184,16 +183,10 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                   />
                 )}
                 {field_super_event && (
-                  <SideContent
-                    header={t('event.Other_times')}
-                    content={
-                      <RelatedEvents
-                        superEvent={field_super_event}
-                        nodeId={node.id}
-                      />
-                    }
-                    icon={<IconCalendarPlus />}
-                  />
+                   <RelatedEvents
+                   superEvent={field_super_event}
+                   nodeId={node.id}
+                 />
                 )}
               </div>
             </div>

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -171,22 +171,22 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                 {field_in_language.length > 0 && (
                   <SideContent
                     header={t('event.languages')}
-                    content={event_languages.toString().replace(',', ', ')}
                     icon={<IconGlobe />}
-                  />
+                  >
+                    {event_languages.toString().replace(',', ', ')}
+                  </SideContent>
                 )}
                 {field_provider && (
                   <SideContent
                     header={t('event.provider')}
-                    content={field_provider}
                     icon={<IconFaceSmile />}
-                  />
+                  >{field_provider}</SideContent>
                 )}
                 {field_super_event && (
-                   <RelatedEvents
-                   superEvent={field_super_event}
-                   nodeId={node.id}
-                 />
+                  <RelatedEvents
+                    superEvent={field_super_event}
+                    nodeId={node.id}
+                  />
                 )}
               </div>
             </div>

--- a/src/components/pageTemplates/NodeEventPage.tsx
+++ b/src/components/pageTemplates/NodeEventPage.tsx
@@ -173,7 +173,7 @@ function NodeEventPage({ node, ...props }: NodeEventPageProps): JSX.Element {
                     header={t('event.languages')}
                     icon={<IconGlobe />}
                   >
-                    {event_languages.toString().replace(',', ', ')}
+                    {event_languages.toString().replaceAll(',', ', ')}
                   </SideContent>
                 )}
                 {field_provider && (

--- a/src/components/sideContent/SideContent.tsx
+++ b/src/components/sideContent/SideContent.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement } from 'react';
+import React, { PropsWithChildren, ReactChildren, ReactElement } from 'react';
 
 import styles from './sideContent.module.scss';
 
 interface SideContent {
     header: string;
-    content: any;
+    content: ReactChildren | PropsWithChildren<any>;
     icon: ReactElement;
 }
 

--- a/src/components/sideContent/SideContent.tsx
+++ b/src/components/sideContent/SideContent.tsx
@@ -4,18 +4,18 @@ import styles from './sideContent.module.scss';
 
 interface SideContent {
     header: string;
-    content: ReactChildren | PropsWithChildren<any>;
+    children: ReactChildren | PropsWithChildren<any>;
     icon: ReactElement;
 }
 
-function SideContent({ header, content, icon }: SideContent) {
+function SideContent({ header, children, icon }: SideContent) {
   return (
     <div className={styles.contentRegionWrapper}>
       <div className={styles.headerContent}>
         {icon}
         <h2 className={styles.contentRegionSubHeader}>{header}</h2>
       </div>
-      <div className={styles.contentRegionText}>{content}</div>
+      <div className={styles.contentRegionText}>{children}</div>
     </div>
   );
 }

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react'
-import getConfig from 'next/config'
-import { useTranslation } from 'next-i18next'
-import { useRouter } from 'next/router'
-import { Locale } from 'next-drupal'
-import { useCookies } from 'hds-react'
-import { setInitialLocale } from '@/lib/helpers'
+import { useEffect, useState } from 'react';
+import getConfig from 'next/config';
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+import { Locale } from 'next-drupal';
+import { useCookies } from 'hds-react';
+import { setInitialLocale } from '@/lib/helpers';
 
 export const useConsentStatus = (cookieId: string) => {
   const { getAllConsents } = useCookies();
@@ -13,9 +13,11 @@ export const useConsentStatus = (cookieId: string) => {
 };
 
 export const useCookieConsents = (): any => {
-  const { locale } = useRouter()
-  const { t } = useTranslation()
-  const [language, setLanguage] = useState<string>(setInitialLocale(locale ? locale : ''));
+  const { locale } = useRouter();
+  const { t } = useTranslation();
+  const [language, setLanguage] = useState<string>(
+    setInitialLocale(locale ? locale : '')
+  );
   const onLanguageChange = (newLang: Locale) => setLanguage(newLang);
 
   /**
@@ -25,12 +27,12 @@ export const useCookieConsents = (): any => {
     matomo_description: {
       fi: 'Matomo-tilastointijärjestelmän eväste.',
       en: 'Matomo Analytics - used to store a few details about the user such as the unique visitor ID.',
-      sv: 'Statistiksystemets kaka samlar information om hur webbplatsen används.'
+      sv: 'Statistiksystemets kaka samlar information om hur webbplatsen används.',
     },
     rns_description: {
       fi: 'React & Share -reaktionappien toimintaan liittyvä tietue.',
       en: 'A record related to the operation of the React & Share react buttons.',
-      sv: 'En post relaterad till driften av reaktionsknappen React & Share.'
+      sv: 'En post relaterad till driften av reaktionsknappen React & Share.',
     },
     period_minutes: {
       fi: 'minuuttia',
@@ -40,9 +42,9 @@ export const useCookieConsents = (): any => {
     period_days: {
       fi: 'päivää',
       en: 'days',
-      sv: 'dagar'
-    }
-  }
+      sv: 'dagar',
+    },
+  };
 
   return {
     siteName: t('site_title'),
@@ -106,71 +108,80 @@ export const useCookieConsents = (): any => {
       /**
        * @TODO Check for better solution to get rid of Cookies needed infobox, when accepting cookies.
        */
-      window.location.reload()
+      window.location.reload();
     },
   };
-} 
+};
 
 export const useMatomo = (cookieConsent: boolean) => {
-  const { MATOMO_URL: url, MATOMO_SITE_ID: siteId } = getConfig().publicRuntimeConfig
+  const { MATOMO_URL: url, MATOMO_SITE_ID: siteId } =
+    getConfig().publicRuntimeConfig;
 
   useEffect(() => {
-    const _paq = (window._paq = window._paq || [])
-    const script = document.createElement("script")
-    script.async = true
-    script.src = `${url}piwik.min.js`
-    script.type = "text/javascript"
-    document.head.appendChild(script)
-  
+    const _paq = (window._paq = window._paq || []);
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `${url}piwik.min.js`;
+    script.type = 'text/javascript';
+    document.head.appendChild(script);
+
     // This means no tracking or cookies unless consent is given.
-    _paq.push(['requireConsent'])
-  
+    _paq.push(['requireConsent']);
+
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(["setCookieDomain", "*.tyollisyyspalvelut.hel.fi"])
-  
-    _paq.push(["trackPageView"])
-  
-    _paq.push(["enableLinkTracking"])
-    _paq.push(["setTrackerUrl", `${url}tracker.php`])
-    _paq.push(["setSiteId", siteId])
-  
+    _paq.push(['setCookieDomain', '*.tyollisyyspalvelut.hel.fi']);
+
+    _paq.push(['trackPageView']);
+
+    _paq.push(['enableLinkTracking']);
+    _paq.push(['setTrackerUrl', `${url}tracker.php`]);
+    _paq.push(['setSiteId', siteId]);
+
     // Enable or disable tracking by the selected consent
-    cookieConsent ? window._paq.push(['setConsentGiven']) : window._paq.push(['forgetConsentGiven'])
-  }, [cookieConsent])
-}
+    cookieConsent
+      ? window._paq.push(['setConsentGiven'])
+      : window._paq.push(['forgetConsentGiven']);
+  }, [cookieConsent]);
+};
 
 export const useReactAndShare = (
   cookieConsent: boolean | undefined,
   lang: string | undefined,
   pageTitle: string | undefined
 ) => {
-    const [reactAndShareApiKey, setReactAndShareApiKey] = useState(getConfig().publicRuntimeConfig.REACT_AND_SHARE_EN)
+  const [reactAndShareApiKey, setReactAndShareApiKey] = useState(
+    getConfig().publicRuntimeConfig.REACT_AND_SHARE_EN
+  );
+
   useEffect(() => {
-    if (cookieConsent !== true) {
-      return
-    }
-
     if (lang === 'fi') {
-      setReactAndShareApiKey(getConfig().publicRuntimeConfig.REACT_AND_SHARE_FI)
+      setReactAndShareApiKey(
+        getConfig().publicRuntimeConfig.REACT_AND_SHARE_FI
+      );
     } else if (lang === 'sv') {
-      setReactAndShareApiKey(getConfig().publicRuntimeConfig.REACT_AND_SHARE_SV)
+      setReactAndShareApiKey(
+        getConfig().publicRuntimeConfig.REACT_AND_SHARE_SV
+      );
+    }
+    if (cookieConsent !== true) {
+      return;
     }
 
-    const script = document.createElement("script")
-    const resourceUrl = 'https://cdn.reactandshare.com/plugin/rns.js'
-    script.src = resourceUrl
-    script.type = "text/javascript"
+    const script = document.createElement('script');
+    const resourceUrl = 'https://cdn.reactandshare.com/plugin/rns.js';
+    script.src = resourceUrl;
+    script.type = 'text/javascript';
 
     window.rnsData = {
       apiKey: reactAndShareApiKey,
       title: pageTitle || 'Työllisyyspalvelut',
       canonicalUrl: window.location.href,
-      categories: ['Työllisyyspalvelut']
-    }
+      categories: ['Työllisyyspalvelut'],
+    };
 
-    document.body.appendChild(script)
+    document.body.appendChild(script);
     return () => {
-      document.body.removeChild(script)
-    }
-  }, [cookieConsent, lang])
-}
+      document.body.removeChild(script);
+    };
+  }, [cookieConsent, lang, pageTitle, reactAndShareApiKey]);
+};


### PR DESCRIPTION
### Notes

- Fixed React and share language.
- Fixed Related Event to fetch data when base event changes.
- Fixed empty super_event fields to be shown on the event page
- Fixed languages to have space in all gaps.

#### Testing

##### React and Share

- put code below to row 155 on the file useAnalytics.ts
```
- console.log(getConfig().publicRuntimeConfig.REACT_AND_SHARE_FI)
- console.log(getConfig().publicRuntimeConfig.REACT_AND_SHARE_EN)
- console.log(getConfig().publicRuntimeConfig.REACT_AND_SHARE_SV)
```
- and put  `console.log('reactAndShareApiKey', reactAndShareApiKey)` before line `window.rnsData = {`
- And see that the reactAndShareApiKey matches with the language of the page

##### Event pages

- Go to some event that has super event.  Try to click some event on the Related event component. You should end up to the page event page and the related events should be updated as well.
- Go to event `Helsingfors stads småbarnspedagogik rekryterar` and see that all the languages on the page has gap between the comma and the next language
- You shouldn't find related event with empty list.



