### PR TITLE
THF-469: Add preview nav to other languages selection

### DIFF
--- a/src/components/navigationComponents/LanguageSelect.tsx
+++ b/src/components/navigationComponents/LanguageSelect.tsx
@@ -114,7 +114,7 @@ function LanguageSelect({
                   {t('global_menu_title')}
                 </div>
                 {menuOtherLanguages?.map((link: any) => (
-                  <a href={link.url} key={link.id}>
+                  <a href={link.url} key={link.id} onClick={() => previewNavigation(link.url, preview)}>
                     <div className={styles.globalLink}>
                       <span>{link.title}</span>
                     </div>


### PR DESCRIPTION
### changes

Added Drupal to follow next-js navigaation in other languages global list.

#### testing
- test navigations, breadcrumb and sidenav on Drulas site. You should be able to navigate in Drupal using navigations, breadcrumb and sidenav.