### PR TITLE
DRAFT: Thf 610 sessionstorage filters

### DIFF
--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -37,10 +37,11 @@ const getTotal = (data: EventData[]) => {
   };
 };
 
-const sessionFilters = () => {
+const sessionFilters = (locale: string) => {
   if (typeof window !== 'undefined') {
     const sessionFilters = sessionStorage.getItem('sessionFilter');
-    if (sessionFilters !== null) {
+    const sessionLocale = sessionStorage.getItem('locale');
+    if (sessionFilters !== null && sessionLocale === locale) {
      return JSON.parse(sessionFilters);
     } else {
       return [];
@@ -73,7 +74,8 @@ export default function Events(props: EventListProps): JSX.Element {
   const { field_title, field_events_list_desc } = props;
   const { t } = useTranslation();
   const { locale } = useRouter();
-  const [filter, setFilter] = useState<string[]>(sessionFilters());
+  const [filter, setFilter] = useState<string[]>(sessionFilters(locale ?? 'fi'));
+  
   const fetcher = (eventsIndex: number) => {
     return getEventsSearch(eventsIndex, filter, locale ?? 'fi');
   };
@@ -111,6 +113,7 @@ export default function Events(props: EventListProps): JSX.Element {
     const handleBeforeUnload = (): void => {
       if (filter !== null && filter !== undefined) {
         sessionStorage.setItem('sessionFilter', JSON.stringify(filter));
+        sessionStorage.setItem('locale', locale ?? 'fi');
       }
       sessionStorage.setItem(
         'screenX',

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -84,10 +84,35 @@ export default function Events(props: EventListProps): JSX.Element {
     });
   }, [locale]);
 
-  useEffect(() => {
-    updateTags();
-    setSize(1);
-  }, [filter, setSize, updateTags]);
+  useEffect(() => {  
+
+    const x =  sessionStorage.getItem('screenX');
+     const sessionFilters = sessionStorage.getItem('sessionFilter');
+     const screenX = sessionStorage.getItem('screenX');
+     if (sessionFilters !== null) {
+       setFilter(JSON.parse(sessionFilters))
+     }
+     if (screenX !== null) {
+       window.scrollTo(0, parseInt(screenX));
+     }
+ },[])
+
+
+   useEffect(() => {
+     updateTags();
+     setSize(1);
+     const handleBeforeUnload = (): void => {
+       if (filter !== null && filter !== undefined) {
+         sessionStorage.setItem('sessionFilter', JSON.stringify(filter));
+       }
+       sessionStorage.setItem('screenX', document.documentElement.scrollTop.toString())
+     };
+     window.addEventListener('beforeunload', handleBeforeUnload);
+
+     return () => {
+       window.removeEventListener('beforeunload', handleBeforeUnload);
+     };
+   }, [filter, setSize, updateTags]);
 
   return (
     <div className="component">

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { DrupalMenuLinkContent } from 'next-drupal';
-import { GroupingProps, Node } from '@/lib/types';
+import { EventData, GroupingProps, Node } from '@/lib/types';
 import getConfig from 'next/config';
 
 import { BreadcrumbContent } from './types';
@@ -299,4 +299,63 @@ export const groupData = (data: GroupingProps[]) => {
 
 export const setInitialLocale = (locale: string): string => {
   return primaryLanguages.includes(locale) ? locale : 'en';
+};
+
+
+/* event helper */
+
+const urlParams =  typeof window !== 'undefined' ? new URLSearchParams(window.location.search): null;
+
+export const getKey = (eventsIndex: number) => {
+  return `${eventsIndex}`;
+};
+
+export const getEvents = (data: EventData[]) => {
+  /** Filter events object from data */
+  return data.reduce((acc: any, curr: any) => acc.concat(curr.events), []);
+};
+
+export const getTotal = (data: EventData[]) => {
+  /** Filter total from data */
+  return {
+    max: data[0].maxTotal ? data[0].maxTotal : data[0].total,
+    current: data[0].total,
+  };
+};
+
+export const getSessionFilters = () => {
+  if (typeof window !== 'undefined' && urlParams !== null) {
+    if (urlParams.getAll('tag')) {
+      return urlParams.getAll('tag');
+    } else {
+      return [];
+    }
+  } else {
+    return [];
+  }
+};
+
+export const getAvailableTag = (events: any) => {
+  const availableTags: string[] = [];
+  events
+    ?.map((event: { field_event_tags: string[] }) => event?.field_event_tags)
+    .forEach((field_event_tag: string[]) =>
+      field_event_tag?.forEach((tag: string) =>
+        !availableTags.includes(tag) ? availableTags.push(tag) : null
+      )
+    );
+  return availableTags;
+};
+
+export const keepScrollPosition = () => {
+  if (typeof window !== 'undefined' && urlParams !== null) {
+    const screenX = sessionStorage.getItem('screenX');
+    if (screenX !== null && urlParams.get('tag')) {
+      const position = parseInt(screenX);
+      window.scrollTo(0, position);
+      sessionStorage.removeItem('screenX');
+    } else {
+      return;
+    }
+  }
 };


### PR DESCRIPTION
### Notes

Added sessionStorage handling to events.ts. Shortly the variables added to storage last in on tab. 

#### Small summary of sessionStorage

Each browser tab creates a unique, tab-specific page session that lasts as long as the tab or browser remains open, persisting even through page reloads and restores. 

If you open a new tab or window with the same URL, a separate sessionStorage is created for each tab/window, maintaining isolation. Duplicating a tab will also duplicate its sessionStorage contents into the new tab.

However, once you close a tab or window, its session ends, and any data stored in its sessionStorage is cleared.

**More info about sessionStorage** https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage


#### Questions

- is the sessionStorage logic what we hope? Example at least one big webstore has this kind of behavior. 
- Events.ts file starts to be too long. If asked from me. Should we create own helper file for the extra function that the file has? https://github.com/City-of-Helsinki/employment-services-ui/blob/1eee2ed3bf13f08eddcf7d897814ee5620a15cc1/src/components/events/Events.tsx
- Also the JXS is too long. Should be at least 2 different component. Should we do this?
- What about "scroll to the top" button? I think we would need it.
- When changing language of the page the filter is now emptied. Can you think better way?
- One more note, did you want those selected filters in the localstorage or also in the URL?
 