### PR TITLE
THF-615: get only opening hours object

### DIFF
--- a/src/components/pageTemplates/NodeTprUnitPage.tsx
+++ b/src/components/pageTemplates/NodeTprUnitPage.tsx
@@ -54,6 +54,10 @@ function NodeTprUnitPage({
       : otherContent.push(content)
   );
 
+  const openingHours = opening_hours.filter(
+    (open: { type: string }) => open.type === 'OPENING_HOURS'
+  );
+
   return (
     <article>
       <Container className="container">
@@ -66,7 +70,7 @@ function NodeTprUnitPage({
               email={email}
               address={address}
               address_postal={address_postal}
-              opening_hours={opening_hours}
+              opening_hours={openingHours}
               call_charge_info={call_charge_info}
               service_map_embed={service_map_embed}
             />
@@ -88,7 +92,7 @@ function NodeTprUnitPage({
               email={email}
               address={address}
               address_postal={address_postal}
-              opening_hours={opening_hours}
+              opening_hours={openingHours}
               call_charge_info={call_charge_info}
               service_map_embed={service_map_embed}
             />


### PR DESCRIPTION
### Changes

Changed opening hours object to take only object with type `opening_hours`

#### Testing

- Test all offices http://localhost:3000/yhteystiedot/toimipisteet
- You should have office hours filled in all offices. 
- 
<img width="329" alt="Screenshot 2023-09-26 at 12 40 17" src="https://github.com/City-of-Helsinki/employment-services-ui/assets/42113018/9b2408af-3e3d-4e49-b2b6-7c8c738d0ebb">
