### PR TITLE
THF-624: newslist date show created time  when Article is scheduled

### DIFF
--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -32,6 +32,7 @@ interface News {
   title: string;
   status: boolean;
   field_article_category: string;
+  created: string;
 }
 
 interface Path {
@@ -62,6 +63,11 @@ function NewsList({
   }, [news, newsIndex]);
 
   const loadMoreText = t('list.load_more');
+
+  const getArticleDate = (published_at: string | null, created: string) => {
+   return published_at !== null && published_at > created ? published_at : created;
+  }
+  
   return (
     <div
       className="component"
@@ -94,8 +100,8 @@ function NewsList({
               )}
               {news.published_at && (
                 <p className={styles.articleDate}>
-                  <time dateTime={news.published_at}>{`${dateformat(
-                    news.published_at,
+                  <time dateTime={getArticleDate(news.published_at, news.created)}>{`${dateformat(
+                    getArticleDate(news.published_at, news.created),
                     'dd.mm.yyyy'
                   )}`}</time>
                 </p>


### PR DESCRIPTION
### Fix

When created day is greater than published_at we will show the created date and get right date for scheduled Articles.

### Testing

1. Navigate to page http://localhost:3000/ajankohtaista/uutiset.
2. In the 'src/components/news/NewsList.tsx' file, insert the following code:
3. `console.log('news', news);`
4. Open the developer tools console tab in your web browser.
5. If your data already contains scheduled articles, you can skip steps 6 and 7.
6. If there are no scheduled articles, create a new article and schedule its publication for two minutes in the future. Save the article.
7. After waiting for two minutes, run the 'cron-run' command.
8. Examine several articles to ensure their 'created date' is earlier than their 'published_at' date. You should see the 'created date' displayed on the page if it's greater, and you should see the 'published_at' date if it's greater.


