### PR TITLE
THF-637: Added new event_index to event components

### DIFF
--- a/pages/api/events-search.ts
+++ b/pages/api/events-search.ts
@@ -14,6 +14,7 @@ interface Terms {
   terms: {
     field_event_tags?: string[],
     langcode?: string[],
+    field_in_language?: string[],
   } 
 }
 
@@ -27,7 +28,7 @@ export default async function handler(
     return;
   }
 
-  const { index, filter, locale }: Index = req?.query || {};
+  const { index, filter, languageFilter, locale }: Index = req?.query || {};
 
   if (isNaN(Number(index))) {
     res.status(400);
@@ -61,6 +62,15 @@ export default async function handler(
     const objectFilter = {
       terms: {
         langcode: getQueryFilterTags(locale),
+      },
+    };
+    queryBody.push(objectFilter);
+  }
+
+  if (languageFilter) {
+    const objectFilter = {
+      terms: {
+        field_in_language: getQueryFilterTags(languageFilter),
       },
     };
     queryBody.push(objectFilter);
@@ -154,6 +164,7 @@ const getFilteredEvents = (filterTags: string[] | undefined, hits: any) => {
         field_street_address,
         field_event_status,
         langcode,
+        field_in_language,
       } = hit._source as EventData;
       if (
         filterTags === undefined ||
@@ -177,6 +188,7 @@ const getFilteredEvents = (filterTags: string[] | undefined, hits: any) => {
           field_street_address,
           field_event_status,
           langcode,
+          field_in_language,
         };
       } else {
         return;

--- a/pages/api/events-search.ts
+++ b/pages/api/events-search.ts
@@ -29,7 +29,7 @@ export default async function handler(
     return;
   }
 
-  const { index, eventTagId, eventTagName, languageTagId, locale }: Index =
+  const { index, eventTagId, languageTagId, locale }: Index =
     req?.query || {};
 
   if (isNaN(Number(index))) {
@@ -101,7 +101,7 @@ export default async function handler(
     res.status(500);
   }
 
-  if (eventTagId) {
+  if (languageTagId) {
     try {
       const searchRes = await elastic.search({
         index: `event_index`,
@@ -116,9 +116,9 @@ export default async function handler(
         },
       });
       const {
-        hits: { total },
+        hits: { total, hits },
       } = searchRes as {
-        hits: { total: SearchTotalHits };
+        hits: { total: SearchTotalHits, hits: any };
       };
 
       response = {
@@ -130,7 +130,7 @@ export default async function handler(
       res.status(500);
     }
   }
-  res.json(response);
+    res.json(response);
 }
 
 const getLanguage = (languageTagId: string, locale: string) => {

--- a/pages/api/events-search.ts
+++ b/pages/api/events-search.ts
@@ -6,6 +6,7 @@ import {
 
 import * as Elastic from '@/lib/elasticsearch';
 import { EventState, EventData } from '@/lib/types';
+import { drupalLanguages } from '@/lib/helpers';
 
 type Data = EventState;
 type Index = Partial<{ [key: string]: string | string[] }>;
@@ -14,7 +15,7 @@ interface Terms {
   terms: {
     field_event_tags?: string[],
     langcode?: string[],
-    field_in_language?: string[],
+    field_in_language?: any,
   } 
 }
 
@@ -28,7 +29,7 @@ export default async function handler(
     return;
   }
 
-  const { index, filter, languageFilter, locale }: Index = req?.query || {};
+  const { index, filter, languageFilter, languageId, locale }: Index = req?.query || {};
 
   if (isNaN(Number(index))) {
     res.status(400);
@@ -61,12 +62,14 @@ export default async function handler(
   if (locale) {
     const objectFilter = {
       terms: {
-        langcode: getQueryFilterTags(locale),
+        langcode: 
+          drupalLanguages.includes(languageId as string) && languageId ? [languageId] : [locale]
+        ,
       },
     };
-    queryBody.push(objectFilter);
+    queryBody.push(objectFilter as Terms);
   }
-
+  
   if (languageFilter) {
     const objectFilter = {
       terms: {

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -1,17 +1,28 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<any>
 ) {
-  const { tagField }: Partial<{ [key: string]: string | string[] }> =
-    req?.query || {};
+  try {
+    const { tagField }: Partial<{ [key: string]: string | string[] }> =
+      req?.query || {};
 
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/jsonapi/taxonomy_term/${tagField}`
-  );
-  const data = await response.json();
+    if (!tagField) {
+      throw new Error('Invalid or missing tagField parameter');
+    }
 
-  res.status(200).json(data);
+    const apiUrl = `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/jsonapi/taxonomy_term/${tagField}`;
+    const response = await fetch(apiUrl);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch data from ${apiUrl}`);
+    }
+
+    const data = await response.json();
+
+    res.status(200).json(data);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
 }
-  

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -8,7 +8,7 @@ export default async function handler(
     req?.query || {};
 
   const response = await fetch(
-    `https://drupal-tyollisyyspalvelut-helfi.docker.so/jsonapi/taxonomy_term/${tagField}`
+    `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/jsonapi/taxonomy_term/${tagField}`
   );
   const data = await response.json();
 

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -5,14 +5,19 @@ export default async function handler(
   res: NextApiResponse<any>
 ) {
   try {
-    const { tagField }: Partial<{ [key: string]: string | string[] }> =
+    const { tagField, locale }: Partial<{ [key: string]: string | string[] }> =
       req?.query || {};
 
     if (!tagField) {
       throw new Error('Invalid or missing tagField parameter');
     }
 
-    const apiUrl = `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/jsonapi/taxonomy_term/${tagField}`;
+    const localePath =
+      locale === 'fi'
+        ? `jsonapi/taxonomy_term/${tagField}`
+        : `${locale}/jsonapi/taxonomy_term/${tagField}`;
+
+    const apiUrl = `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${localePath}`;
     const response = await fetch(apiUrl);
 
     if (!response.ok) {

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -1,62 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import * as Elastic from '@/lib/elasticsearch';
-
-
-interface QueryBody {
-  query: {
-    match: object,
-  },
-  size: number,
-  aggs: {
-    events_tags: {
-      terms: {
-        field: string,
-        size: number,
-      },
-    },
-  },
-}
-
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<any>
 ) {
-  const { tagField, locale }: Partial<{ [key: string]: string | string[]; }> = req?.query || {};
+  const { tagField }: Partial<{ [key: string]: string | string[] }> =
+    req?.query || {};
 
-  // No posts allowed, no missing params-errors revealed.
-  if (req.method !== 'GET') {
-    res.status(400);
-    return;
-  }
-  const elastic = Elastic.getElasticClient();
+  const response = await fetch(
+    `https://drupal-tyollisyyspalvelut-helfi.docker.so/jsonapi/taxonomy_term/${tagField}`
+  );
+  const data = await response.json();
 
-  const body: QueryBody = {
-    query: {
-      match: { langcode: String(locale) ?? 'fi' } ,
-    },
-    size: 0,
-    aggs: {
-      events_tags: {
-        terms: {
-          field: tagField as string,
-          size: 100,
-        },
-      },
-    },
-  };
-
-  try {
-    const searchRes = await elastic.search({
-      index: `event_index`,
-      body: body,
-    });
-
-    const { events_tags }: any = searchRes.aggregations;
-
-    res.json(events_tags?.buckets);
-  } catch (err) {
-    console.log('err', err);
-    res.status(500);
-  }
+  res.status(200).json(data);
 }
+  

--- a/pages/api/events-tags.ts
+++ b/pages/api/events-tags.ts
@@ -4,7 +4,7 @@ import * as Elastic from '@/lib/elasticsearch';
 
 interface QueryBody {
   query: {
-    match_all: object,
+    match: object,
   },
   size: number,
   aggs: {
@@ -33,7 +33,7 @@ export default async function handler(
 
   const body: QueryBody = {
     query: {
-      match_all: {},
+      match: { langcode: String(locale) ?? 'fi' } ,
     },
     size: 0,
     aggs: {
@@ -48,7 +48,7 @@ export default async function handler(
 
   try {
     const searchRes = await elastic.search({
-      index: `events_${locale}`,
+      index: `event_index`,
       body: body,
     });
 

--- a/pages/api/events.ts
+++ b/pages/api/events.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import qs from "qs";
+
 import * as Elastic from '@/lib/elasticsearch';
 import { EventData, EventsQueryParams } from '@/lib/types'
-import qs from "qs";
-import { SearchHit, SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 
 type Data = {
   name: string
@@ -42,6 +43,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   const queryBody: Terms[] = body.query.bool.filter;
 
+  if (locale) {
+    const objectFilter = {
+      terms: {
+        langcode: [locale],
+      },
+    };
+    queryBody.push(objectFilter as Terms);
+  }
+
   if (tags) {
     const objectFilter = {
       terms: {
@@ -62,7 +72,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   try {
     const searchRes = await elastic.search({
-      index: `events_${locale ?? 'fi'}`,
+      index: `event_index`,
       body: body,
       sort: 'field_end_time:asc',
     });

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -24,7 +24,7 @@
   "search": {
     "filter": "Select topics",
     "filter_lang": "Select languages",
-    "dropdown_label": "Event languages",
+    "dropdown_label": "Event language",
     "clear": "Clear all filters",
     "title": "Search the Employment Services website",
     "page_title": "Search",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -23,7 +23,7 @@
   },
   "search": {
     "filter": "Select topics",
-    "filter_lang": "Select languages",
+    "filter_lang": "Select language",
     "dropdown_label": "Event language",
     "clear": "Clear all filters",
     "title": "Search the Employment Services website",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -23,8 +23,8 @@
   },
   "search": {
     "filter": "Valitse aiheet",
-    "filter_lang": "Valitse kielet",
-    "dropdown_label": "Ohjauskielet",
+    "filter_lang": "Valitse kieli",
+    "dropdown_label": "Valitse kieli",
     "clear": "Poista kaikki valinnat",
     "title": "Hae työllisyyspalveluiden sivuilta",
     "page_title": "Haku",

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -20,6 +20,7 @@ import styles from './events.module.scss';
 import ButtonFilter from '../eventsComponents/ButtonFilter';
 import EventListComponent from '../eventsComponents/EventListComponent';
 import HtmlBlock from '../HtmlBlock';
+import ResponsiveFilterMapper from '../eventsComponents/ResponsiveFilterMapper';
 
 export default function Events(props: EventListProps): JSX.Element {
   const { field_title, field_events_list_desc } = props;
@@ -60,9 +61,9 @@ export default function Events(props: EventListProps): JSX.Element {
           })
         );
         setEventsLanguageTags(updatedTerms);
-      });
+      });  
 
-    getEventsTags('event_tags', locale ?? 'fi')
+      getEventsTags('event_tags', languageFilter[0]?.Id ?? locale)
       .then((response) => response.data)
       .then((data) => data.map((term: any) => term.attributes))
       .then((result) => {
@@ -84,18 +85,19 @@ export default function Events(props: EventListProps): JSX.Element {
         : [...filter];
       setFilter(tagEvent);
     }
-    if (eventsLanguageTags && eventsLanguageTags.length > 0) {
+        if (eventsLanguageTags && eventsLanguageTags.length > 0) {      
       const tagEvent = isFirstElementString(languageFilter)
-        ? eventsLanguageTags.filter((tag: any) => languageFilter.includes(tag.name))
+        ? eventsLanguageTags.filter((tag: any) => languageFilter.includes(tag.id))
         : [...languageFilter];
       setLanguageFilter(tagEvent);
     }
     
   }, [eventsTags, eventsLanguageTags]);
   
-
   const isFirstElementString = (array: any) => {
-    return typeof array[0] === 'string' ? true : false;
+    return array !== null && array !== undefined && typeof array[0] === 'string'
+      ? true
+      : false;
   };
 
   const updateURL = useCallback(() => {
@@ -141,25 +143,14 @@ export default function Events(props: EventListProps): JSX.Element {
       : `${total?.max} ${t('list.results_text')}`;
   };
 
-  // const getInitialOptions = () => {
-  //   const dropdownOptions: { label: string }[] = [];
-  //   eventsLanguageTags.map((option: string) =>
-  //     dropdownOptions.push({ label: option })
-  //   );
-  //   return dropdownOptions;
-  // };
-
-  // const getSelectedOptions = (): { label: string }[] => {
-  //   const currentOptionSelected: { label: string }[] = [];
-  //   const available = getAvailableTags(events, 'field_in_language');
-
-  //   languageFilter.map((option: string) => {
-  //     available.includes(option)
-  //       ? currentOptionSelected.push({ label: option })
-  //       : null;
-  //   });
-  //   return currentOptionSelected;
-  // };
+  const getInitialOptions = () => {
+      const dropdownOptions: { value: string, label: string }[] = [];
+      
+      eventsLanguageTags.map((option: {id: string, name: string}) =>
+       dropdownOptions.push({ value: option.id, label: option.name })
+      );
+      return dropdownOptions;
+  };
 
   return (
     <div className="component" onLoad={() => keepScrollPosition()}>
@@ -180,13 +171,17 @@ export default function Events(props: EventListProps): JSX.Element {
             availableTags={getAvailableTags(events, 'field_event_tags_id')}
             filterLabel={'search.filter'}
           />
-          <ButtonFilter
+
+        <ResponsiveFilterMapper
             tags={eventsLanguageTags}
             setFilter={setLanguageFilter}
-            filter={languageFilter as any}
+            filter={languageFilter}
             availableTags={getAvailableTags(events, 'field_language_id')}
             filterLabel={'search.filter_lang'}
-            setAvailableTags={filter?.length > 0}
+            setAvailableTags={filter.length > 0}
+            dropdownLabel={'search.dropdown_label'}
+            initialOptions={getInitialOptions()}
+            select={languageFilter}
           />
 
           <HDSButton

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -34,7 +34,7 @@ export default function Events(props: EventListProps): JSX.Element {
       ? `${slug[0]}/${slug[1]}`
       : `${locale}/${slug[0]}/${slug[1]}`;
 
-  const [languageFilter, setLanguageFilter] = useState<string[]>(
+  const [languageFilter, setLanguageFilter] = useState<any>(
     getInitialFilters('lang', locale ?? 'fi')
   );
 
@@ -50,16 +50,15 @@ export default function Events(props: EventListProps): JSX.Element {
   const [eventsTags, setEventsTags] = useState<any>([]);
   const [eventsLanguageTags, setEventsLanguageTags] = useState<any>([]);
 
-
 const updateTags = useCallback(() => {
   getEventsTags('event_languages')
   .then((response) => response.data)
   .then((data) => data.map((term: any) => term.attributes))
   .then((result) => {
-    const updatedTerms = result.map((x: { field_language_id: string, name: string }) => ({
-      id: x.field_language_id,
-      name: x.name,
-    }));
+    const updatedTerms = result.map((tag: { field_language_id: string, name: string }) => ({
+      id: tag.field_language_id,
+      name: tag.name,
+    }))
     setEventsLanguageTags(updatedTerms);
   });
 
@@ -68,7 +67,7 @@ const updateTags = useCallback(() => {
     .then((data) => data.map((term: any) => term.attributes))
     .then((result) => {
       const tags: string[] = result
-        .map((x: { name: string }) => x.name)
+        .map((tag: { name: string }) => tag.name)
         .sort(
           (a: string, b: string) =>
             eventTags.indexOf(a) - eventTags.indexOf(b)
@@ -76,7 +75,7 @@ const updateTags = useCallback(() => {
       setEventsTags(tags);
     });
 
-  handlePageURL(filter,languageFilter, router, basePath);
+  handlePageURL(filter, languageFilter, router, basePath);
 }, [locale, filter, languageFilter]);
 
   useEffect(() => {
@@ -145,16 +144,16 @@ const updateTags = useCallback(() => {
         )}
         <div role="group">
           <h2>{t('search.header')}</h2>
-          <ButtonFilter
+          {/* <ButtonFilter
             tags={eventsTags}
             events={events}
             setFilter={setFilter}
             filter={filter}
             filterField={'field_event_tags'}
             filterLabel={'search.filter'}
-          />
+          /> */}
           <ButtonFilter
-            tags={eventsLanguageTags.map((tag: any) => tag.name)}
+            tags={eventsLanguageTags}
             events={events}
             setFilter={setLanguageFilter}
             filter={languageFilter}

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -63,7 +63,7 @@ export default function Events(props: EventListProps): JSX.Element {
           const updatedTerms = result.map(
             (tag: { field_language_id: string; field_display_name: string, name: string }) => ({
               id: tag.field_language_id,
-              name: tag.field_display_name || tag.name, //,
+              name: tag.field_display_name || tag.name,
             })
           );
           setEventsLanguageTags(updatedTerms);
@@ -84,6 +84,9 @@ export default function Events(props: EventListProps): JSX.Element {
               name_en: string;
               name_fi: string;
               name_sv: string;
+              name_so: string;
+              name_ua: string;
+              name_ru: string;
             };
           } = {};
     
@@ -95,6 +98,9 @@ export default function Events(props: EventListProps): JSX.Element {
                 name_en: tag.langcode === 'en' ? tag.name : '',
                 name_fi: tag.langcode === 'fi' ? tag.name : '',
                 name_sv: tag.langcode === 'sv' ? tag.name : '',
+                name_so: tag.langcode === 'so' ? tag.name : '',
+                name_ua: tag.langcode === 'ua' ? tag.name : '',
+                name_ru: tag.langcode === 'ru' ? tag.name : '',
               };
             } else {
               if (tag.langcode === 'en') {
@@ -103,12 +109,20 @@ export default function Events(props: EventListProps): JSX.Element {
                 groupedTags[id].name_fi = tag.name;
               } else if (tag.langcode === 'sv') {
                 groupedTags[id].name_sv = tag.name;
+              } else if (tag.langcode === 'so') {
+                groupedTags[id].name_so = tag.name;
+              } else if (tag.langcode === 'ua') {
+                groupedTags[id].name_ua = tag.name;
+              } else if (tag.langcode === 'ru') {
+                groupedTags[id].name_ru = tag.name;
               }
             }
           });
     
           const resultArray = Object.values(groupedTags);
           setEventsTags(resultArray);
+          console.log('resultArray', resultArray);
+          
         })
         .catch((error) => {
           console.error('Error fetching event tags:', error);

--- a/src/components/events/events.module.scss
+++ b/src/components/events/events.module.scss
@@ -149,6 +149,40 @@
   }
 }
 
+.dropdownFilter {
+  --placeholder-color: var(--color-black-90) !important;
+  --focus-outline-color: var(--color-suomenlinna-medium-light) !important;
+  [class*="FieldLabel-module_label"] {
+    font-weight: 700;
+    padding-top: var(--spacing-s);
+    padding-bottom: var(--spacing-2-xs);
+  }
+  [class*="tag_hds-tag"] {
+    --tag-background: var(--color-black-90);
+    --tag-color: var(--color-white);
+    padding-left: 0.27rem;
+    font-family: inherit;
+    font-size: 100%;
+    font-weight: 500;
+    span:first-letter {
+      text-transform: capitalize;
+    }
+  }
+  [class*="Combobox-module_menuItem"] {
+    --multiselect-checkbox-color-selected: var(--color-white);
+    --multiselect-checkbox-background-selected: var(--color-black-90);
+    --multiselect-checkbox-border-hover: var(--color-suomenlinna-medium-light);
+  }
+  [class*="Combobox-module_menuItem"]:first-letter {
+    text-transform: capitalize;
+  }
+  [class*="tag_hds-tag__delete-button"] {
+    svg {
+      display: none;
+    }
+  }
+}
+
 ul.tags {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/eventsComponents/ButtonFilter.tsx
+++ b/src/components/eventsComponents/ButtonFilter.tsx
@@ -33,34 +33,36 @@ function ButtonFilter({
         aria-label={t('search.group_description')}
         className={styles.filterTags}
       >
-        {tags?.map((tag: string, i: number) => (
+        {tags?.map((tag:any, i: number) => (
           <Button
+          value="value"
             disabled={
               setAvailableTags
                 ? !getAvailableTags(events, filterField).includes(tag)
                 : false
             }
             role="checkbox"
-            aria-checked={filter.includes(tag)}
-            aria-label={`${t(filterLabel)} ${tag.replace('_', ' ')}`}
+            aria-checked={filter.map((tag: any) => tag.name).includes(tag.name)}
+            aria-label={`${t(filterLabel)} ${tag.name.replace('_', ' ')}`}
             key={`tagFilter-${i}`}
             className={
-              filter.includes(tag) &&
-              getAvailableTags(events, filterField).includes(tag)
+              filter.map((tag: any) => tag.name).includes(tag.name) &&
+              getAvailableTags(events, filterField).includes(tag.name)
                 ? styles.selected
                 : styles.filterTag
             }
             onClick={() =>
-              setFilter((current: string[]) =>
-                current?.includes(tag)
-                  ? [...current].filter(function (item) {
-                      return item !== tag;
-                    })
-                  : [...current, tag]
-              )
+              // setFilter((current: string[]) =>
+              //   current?.includes(tag)
+              //     ? [...current].filter(function (item) {
+              //         return item !== tag;
+              //       })
+              //     : [...current, tag]
+              // )
+              setFilter([tag])
             }
           >
-            {tag.replace('_', ' ')}
+            {tag.name.replace('_', ' ')}
           </Button>
         ))}
       </div>

--- a/src/components/eventsComponents/ButtonFilter.tsx
+++ b/src/components/eventsComponents/ButtonFilter.tsx
@@ -1,26 +1,22 @@
-import { Button } from 'hds-react';
 import { useTranslation } from 'next-i18next';
+import { Button } from 'hds-react';
 
-import { getAvailableTags } from '@/lib/helpers';
-import { EventData } from '@/lib/types';
 import styles from '../events/events.module.scss';
 
 interface ButtonFilterProps {
   tags: string[];
-  events: EventData[];
-  setFilter: (newFilter: any) => void; 
-  filter: string[];
-  filterField: string;
+  setFilter: (newFilter: any) => void;
+  filter: [{ name: string; id: string }];
+  availableTags: any;
   filterLabel: string;
-  setAvailableTags?: boolean;
+  setAvailableTags?: any;
 }
 
 function ButtonFilter({
-    tags,
-  events,
+  tags,
   setFilter,
   filter,
-  filterField,
+  availableTags,
   filterLabel,
   setAvailableTags = true,
 }: ButtonFilterProps) {
@@ -33,34 +29,28 @@ function ButtonFilter({
         aria-label={t('search.group_description')}
         className={styles.filterTags}
       >
-        {tags?.map((tag:any, i: number) => (
+        {tags?.map((tag: any, i: number) => (
           <Button
-          value="value"
-            disabled={
-              setAvailableTags
-                ? !getAvailableTags(events, filterField).includes(tag)
-                : false
-            }
+            disabled={setAvailableTags ? !availableTags.includes(tag.id) : false}
             role="checkbox"
-            aria-checked={filter.map((tag: any) => tag.name).includes(tag.name)}
+            aria-checked={filter.map((tag: any) => tag.id).includes(tag.id)}
             aria-label={`${t(filterLabel)} ${tag.name.replace('_', ' ')}`}
             key={`tagFilter-${i}`}
             className={
-              filter.map((tag: any) => tag.name).includes(tag.name) &&
-              getAvailableTags(events, filterField).includes(tag.name)
+              filter.map((tag: any) => tag.id).includes(tag.id) &&
+              availableTags.includes(tag.id)
                 ? styles.selected
                 : styles.filterTag
             }
-            onClick={() =>
-              // setFilter((current: string[]) =>
-              //   current?.includes(tag)
-              //     ? [...current].filter(function (item) {
-              //         return item !== tag;
-              //       })
-              //     : [...current, tag]
-              // )
-              setFilter([tag])
-            }
+            onClick={() => {
+              setFilter((current: string[]) =>
+                filterLabel === 'search.filter_lang' && !(current?.includes(tag))
+                  ? [tag]
+                  : current?.includes(tag)
+                  ? current.filter((item) => item !== tag)
+                  : [...current, tag]
+              );
+            }}
           >
             {tag.name.replace('_', ' ')}
           </Button>

--- a/src/components/eventsComponents/ButtonFilter.tsx
+++ b/src/components/eventsComponents/ButtonFilter.tsx
@@ -20,7 +20,24 @@ function ButtonFilter({
   filterLabel,
   setAvailableTags = true,
 }: ButtonFilterProps) {
-  const { t } = useTranslation();
+  const { t } = useTranslation();  
+
+  const handleFilterLang = (
+    current: { id: string; name: string }[],
+    tag: { id: string; name: string }
+  ) => (current.findIndex((item) => item.id === tag.id) !== -1 ? [] : [tag]);
+
+  const handleFilterEvent = (
+    current: { id: string; name: string }[],
+    tag: { id: string; name: string }
+  ) => {
+    const tagIndex = current.findIndex((item) => item.id === tag.id);
+    return tagIndex !== -1
+      ? [...current.slice(0, tagIndex), ...current.slice(tagIndex + 1)]
+      : [...current, tag];
+  };
+  
+
   return (
     <div>
       <div className={styles.filter}>{t(filterLabel)}</div>
@@ -31,24 +48,24 @@ function ButtonFilter({
       >
         {tags?.map((tag: any, i: number) => (
           <Button
-            disabled={setAvailableTags ? !availableTags.includes(tag.id) : false}
+            disabled={
+              setAvailableTags ? !availableTags.includes(tag.id) : false
+            }
             role="checkbox"
-            aria-checked={filter.map((tag: any) => tag.id).includes(tag.id)}
+            aria-checked={Array.isArray(filter) && filter.map((tag: any) => tag.id).includes(tag.id)}
             aria-label={`${t(filterLabel)} ${tag.name.replace('_', ' ')}`}
             key={`tagFilter-${i}`}
             className={
-              filter.map((tag: any) => tag.id).includes(tag.id) &&
+              Array.isArray(filter) && filter?.map((tag: any) => tag.id).includes(tag.id) &&
               availableTags.includes(tag.id)
                 ? styles.selected
                 : styles.filterTag
             }
             onClick={() => {
-              setFilter((current: string[]) =>
-                filterLabel === 'search.filter_lang' && !(current?.includes(tag))
-                  ? [tag]
-                  : current?.includes(tag)
-                  ? current.filter((item) => item !== tag)
-                  : [...current, tag]
+              setFilter((current: { id: string; name: string }[]) =>
+                filterLabel === 'search.filter_lang'
+                  ? handleFilterLang(current, tag)
+                  : handleFilterEvent(current, tag) 
               );
             }}
           >

--- a/src/components/eventsComponents/ButtonFilter.tsx
+++ b/src/components/eventsComponents/ButtonFilter.tsx
@@ -10,7 +10,9 @@ interface ButtonFilterProps {
   availableTags: any;
   filterLabel: string;
   setAvailableTags?: any;
+  language?: any;
 }
+
 
 function ButtonFilter({
   tags,
@@ -19,13 +21,13 @@ function ButtonFilter({
   availableTags,
   filterLabel,
   setAvailableTags = true,
+  language
 }: ButtonFilterProps) {
-  const { t } = useTranslation();  
-
+  const { t } = useTranslation();
   const handleFilterLang = (
     current: { id: string; name: string }[],
     tag: { id: string; name: string }
-  ) => (current.findIndex((item) => item.id === tag.id) !== -1 ? [] : [tag]);
+  ) => (current?.findIndex((item) => item.id === tag.id) !== -1 ? [] : [tag]);
 
   const handleFilterEvent = (
     current: { id: string; name: string }[],
@@ -36,7 +38,8 @@ function ButtonFilter({
       ? [...current.slice(0, tagIndex), ...current.slice(tagIndex + 1)]
       : [...current, tag];
   };
-  
+
+  const nameLang = `name_${language}`;
 
   return (
     <div>
@@ -52,11 +55,19 @@ function ButtonFilter({
               setAvailableTags ? !availableTags.includes(tag.id) : false
             }
             role="checkbox"
-            aria-checked={Array.isArray(filter) && filter.map((tag: any) => tag.id).includes(tag.id)}
-            aria-label={`${t(filterLabel)} ${tag.name.replace('_', ' ')}`}
+            aria-checked={
+              Array.isArray(filter) &&
+              filter.map((tag: any) => tag.id).includes(tag.id)
+            }
+            aria-label={`${t(filterLabel)} ${
+              filterLabel === 'search.filter_lang'
+                ? tag.name.replace('_', ' ')
+                : tag[nameLang].replace('_', ' ')
+            }`}
             key={`tagFilter-${i}`}
             className={
-              Array.isArray(filter) && filter?.map((tag: any) => tag.id).includes(tag.id) &&
+              Array.isArray(filter) &&
+              filter?.map((tag: any) => tag.id).includes(tag.id) &&
               availableTags.includes(tag.id)
                 ? styles.selected
                 : styles.filterTag
@@ -65,11 +76,13 @@ function ButtonFilter({
               setFilter((current: { id: string; name: string }[]) =>
                 filterLabel === 'search.filter_lang'
                   ? handleFilterLang(current, tag)
-                  : handleFilterEvent(current, tag) 
+                  : handleFilterEvent(current, tag)
               );
             }}
           >
-            {tag.name.replace('_', ' ')}
+            {filterLabel === 'search.filter_lang'
+              ? tag.name.replace('_', ' ')
+              : tag[nameLang].replace('_', ' ')}
           </Button>
         ))}
       </div>

--- a/src/components/eventsComponents/DropdownFilter.tsx
+++ b/src/components/eventsComponents/DropdownFilter.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { Combobox } from 'hds-react';
+
+import styles from '../events/events.module.scss';
+
+interface DropdownFilterProps {
+  setAvailableTags?: boolean;
+  setFilter: (newFilter: any) => void;
+  initialOptions: any;
+  filterLabel: string;
+  dropdownLabel: string;
+  availableTags: any;
+  select: any;
+}
+
+function DropdownFilter({
+  setAvailableTags = true,
+  setFilter,
+  initialOptions,
+  filterLabel,
+  dropdownLabel,
+  availableTags,
+  select,
+}: DropdownFilterProps) {
+  const { t } = useTranslation();
+  const [domLoaded, setDomLoaded] = useState<boolean>(false);
+  const [currentOptionSelected, setCurrentOptionSelected] = useState<{ value: string, label: string }[]>()
+
+  useEffect(() => {
+    setDomLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    if (
+      select.length === 0 &&
+      currentOptionSelected !== undefined
+    ) {
+      setCurrentOptionSelected([]);
+    } else {
+      select?.map((option: any) => {
+        setCurrentOptionSelected([{ value: option.id, label: option.name }]);
+      });
+    }
+
+  }, [select]);
+
+  return (
+    <div role="group" aria-label={t('search.group_description')}>
+      {domLoaded && (
+        <Combobox
+          multiselect
+          clearable={true}
+          className={styles.dropdownFilter}
+          label={t(dropdownLabel)}
+          placeholder={t(filterLabel)}
+          isOptionDisabled={(option: any) => {
+            return setAvailableTags
+              ? !availableTags.includes(option.value)
+              : false;
+          }}
+          onChange={(selectedOption: { label: string; value: string }[]) => {
+            if (selectedOption.length > 1) {
+              const lastSelected = selectedOption[selectedOption.length - 1];
+              selectedOption.splice(0, selectedOption.length - 1);
+              setFilter([{ id: lastSelected.value, name: lastSelected.label }]);
+            } else if (selectedOption.length === 1) {
+              setFilter([
+                { id: selectedOption[0].value, name: selectedOption[0].label },
+              ]);
+            } else {
+              setFilter([]);
+            }
+          }}
+          value={currentOptionSelected}
+          options={initialOptions}
+          clearButtonAriaLabel={t('search.clear')}
+          selectedItemRemoveButtonAriaLabel="Remove ${value}"
+          toggleButtonAriaLabel="Toggle menu"
+        />
+      )}
+    </div>
+  );
+}
+
+export default DropdownFilter;

--- a/src/components/eventsComponents/DropdownFilter.tsx
+++ b/src/components/eventsComponents/DropdownFilter.tsx
@@ -7,7 +7,7 @@ import styles from '../events/events.module.scss';
 interface DropdownFilterProps {
   setAvailableTags?: boolean;
   setFilter: (newFilter: any) => void;
-  initialOptions: { value: string; label: string }[];
+  initialOptions: { value: string; label: string }[] | [];
   filterLabel: string;
   dropdownLabel: string;
   availableTags: string[];

--- a/src/components/eventsComponents/DropdownFilter.tsx
+++ b/src/components/eventsComponents/DropdownFilter.tsx
@@ -7,11 +7,11 @@ import styles from '../events/events.module.scss';
 interface DropdownFilterProps {
   setAvailableTags?: boolean;
   setFilter: (newFilter: any) => void;
-  initialOptions: any;
+  initialOptions: { value: string; label: string }[];
   filterLabel: string;
   dropdownLabel: string;
-  availableTags: any;
-  select: any;
+  availableTags: string[];
+  select: { id: string; name: string }[];
 }
 
 function DropdownFilter({

--- a/src/components/eventsComponents/EventListComponent.tsx
+++ b/src/components/eventsComponents/EventListComponent.tsx
@@ -10,7 +10,7 @@ import { EventData } from '@/lib/types';
 
 function EventListComponent({ events }: { events: EventData[] }) {
     const { t } = useTranslation();
-  return (
+      return (
     <div className={styles.eventList}>
       {events && events.length > 0 ? (
         events.map((event: any, key: number) => (
@@ -35,7 +35,7 @@ function EventListComponent({ events }: { events: EventData[] }) {
               )}
 
               <div className={styles.eventCardContent}>
-                {event.field_tags && event.field_tags.length !== 0 && (
+                {event.field_event_tags && event.field_event_tags.length !== 0 && (
                   <TagList tags={event.field_event_tags} />
                 )}
                 <DateTime

--- a/src/components/eventsComponents/ResponsiveFilterMapper.tsx
+++ b/src/components/eventsComponents/ResponsiveFilterMapper.tsx
@@ -6,18 +6,16 @@ import ButtonFilter from './ButtonFilter';
 interface ResponsiveFilterMapperProps {
   setAvailableTags?: boolean;
   setFilter: (newFilter: any) => void; 
-  filter: any;
+  filter: [{ id: string; name: string }];
   initialOptions: { label: string }[]
-  select: { label: string }[];
   tags: string[];
-  availableTags: any;
+  availableTags: string[];
   filterLabel: string;
   dropdownLabel: string;
 }
 
 function ResponsiveFilterMapper({
   setAvailableTags = true,
-  select,
   initialOptions,
   setFilter,
   filter,
@@ -44,8 +42,8 @@ function ResponsiveFilterMapper({
       <DropdownFilter
         setAvailableTags={setAvailableTags}
         setFilter={setFilter}
-        select={select}
-        initialOptions={initialOptions}
+        select={filter}
+        initialOptions={initialOptions as { value: string; label: string }[]}
         filterLabel={filterLabel}
         dropdownLabel={dropdownLabel}
         availableTags={availableTags}

--- a/src/components/eventsComponents/ResponsiveFilterMapper.tsx
+++ b/src/components/eventsComponents/ResponsiveFilterMapper.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+import DropdownFilter from './DropdownFilter';
+import ButtonFilter from './ButtonFilter';
+
+interface ResponsiveFilterMapperProps {
+  setAvailableTags?: boolean;
+  setFilter: (newFilter: any) => void; 
+  filter: any;
+  initialOptions: { label: string }[]
+  select: { label: string }[];
+  tags: string[];
+  availableTags: any;
+  filterLabel: string;
+  dropdownLabel: string;
+}
+
+function ResponsiveFilterMapper({
+  setAvailableTags = true,
+  select,
+  initialOptions,
+  setFilter,
+  filter,
+  tags,
+  availableTags,
+  filterLabel,
+  dropdownLabel,
+}: ResponsiveFilterMapperProps) {
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    function handleResize() {
+      setIsMobile(window.innerWidth <= 768);
+    }
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  if (isMobile) {
+    return (
+      <DropdownFilter
+        setAvailableTags={setAvailableTags}
+        setFilter={setFilter}
+        select={select}
+        initialOptions={initialOptions}
+        filterLabel={filterLabel}
+        dropdownLabel={dropdownLabel}
+        availableTags={availableTags}
+      />
+    );
+  } else {
+    return (
+      <ButtonFilter
+        tags={tags}
+        setFilter={setFilter}
+        filter={filter}
+        availableTags={availableTags}
+        filterLabel={filterLabel}
+        setAvailableTags={setAvailableTags}
+      />
+    );
+  }
+}
+
+export default ResponsiveFilterMapper;

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -29,13 +29,15 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
 export const getEventsSearch = async (
   eventsIndex: number,
   field_event_tags: string[] | null,
-  field_in_language: string[] | null,
+  language: [{name: string, id: string}],
   locale: Locale
 ) => {
+
   const queryParams = {
     index: eventsIndex,
     filter: field_event_tags,
-    languageFilter: field_in_language,
+    languageFilter: language.map((lang: {name: string}) => lang.name),
+    languageId: language.map((lang: {id: string}) => lang.id),
     locale: locale,
   };
 

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -3,12 +3,14 @@ import qs from 'qs';
 
 import { EventsQueryParams, EventsRelatedQueryParams } from '@/lib/types';
 import { Locale } from 'next-drupal';
+import { stringify } from 'querystring';
+import { drupalLanguages } from './helpers';
 
 /** The Client API urls  */
 const EVENTS_URL = '/api/events';
 const EVENTS_SEARCH_URL = '/api/events-search';
 const EVENTS_TAGS_URL = '/api/events-tags';
-const RELATED_EVENTS = '/api/related-events'
+const RELATED_EVENTS = '/api/related-events';
 const NEWS_URL = '/api/news';
 const UNITS_URL = '/api/units';
 const SEARCH_URL = '/api/search';
@@ -19,8 +21,8 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
   const { data } = await axios(`${EVENTS_URL}`, {
     params:
       queryParams,
-      paramsSerializer: params => {
-        return qs.stringify(params, { arrayFormat: 'repeat' })
+    paramsSerializer: params => {
+      return qs.stringify(params, { arrayFormat: 'repeat' })
       }
   })
   return data;
@@ -28,16 +30,15 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
 
 export const getEventsSearch = async (
   eventsIndex: number,
-  eventTags: [{name: string, id: string}],
-  languageTag: [{name: string, id: string}],
+  eventTags: [{ name: string; id: string }],
+  languageTag: [{ name: string; id: string }],
   locale: Locale
 ) => {
-
   const queryParams = {
     index: eventsIndex,
-    eventTagId: eventTags.map((tag: {id: string}) => tag.id),
-    eventTagName: eventTags.map((tag: {name: string}) => tag.name),
-    languageTagId: languageTag.map((tag: {id: string}) => tag.id),
+    eventTagId: eventTags.map((tag: { id: string }) => tag.id),
+    eventTagName: eventTags.map((tag: { name: string }) => tag.name),
+    languageTagId: languageTag.map((tag: { id: string }) => tag.id),
     locale: locale,
   };
 
@@ -55,8 +56,8 @@ export const getRelatedEvents = async (queryParams: EventsRelatedQueryParams) =>
   const { data } = await axios(`${RELATED_EVENTS}`, {
     params:
       queryParams,
-      paramsSerializer: params => {
-        return qs.stringify(params, { arrayFormat: 'repeat' })
+    paramsSerializer: params => {
+      return qs.stringify(params, { arrayFormat: 'repeat' })
       }
   })
   return data;
@@ -64,14 +65,14 @@ export const getRelatedEvents = async (queryParams: EventsRelatedQueryParams) =>
 
 export const getNews = async (index: number, shortList: any, newsFilter: string, locale: Locale) => {
   const queryParams = { index: index, limit: shortList, filter: newsFilter, locale: locale };
-    const { data } = await axios(`${NEWS_URL}`, {
-      params:
+  const { data } = await axios(`${NEWS_URL}`, {
+    params:
         queryParams,
-        paramsSerializer: params => {
-          return qs.stringify(params, { arrayFormat: 'repeat' })
+    paramsSerializer: params => {
+      return qs.stringify(params, { arrayFormat: 'repeat' })
         }
-    })
-    return data;
+  })
+  return data;
 };
 
 export const getUnits = async (locale: Locale) => {
@@ -90,10 +91,10 @@ export const getSearch = async (
   return data;
 };
 
-export const getEventsTags = async (tagField: string, locale: string ) => {
+export const getEventsTags = async (tagField: string, locale: string) => {
   const { data } = await axios(`${EVENTS_TAGS_URL}`, {
-    params: { tagField: tagField, locale: locale},
-  }); 
+    params: { tagField: tagField, locale: locale },
+  });
   return data;
 };
 

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -28,16 +28,16 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
 
 export const getEventsSearch = async (
   eventsIndex: number,
-  field_event_tags: string[] | null,
-  language: [{name: string, id: string}],
+  eventTags: [{name: string, id: string}],
+  languageTag: [{name: string, id: string}],
   locale: Locale
 ) => {
 
   const queryParams = {
     index: eventsIndex,
-    filter: field_event_tags,
-    languageFilter: language.map((lang: {name: string}) => lang.name),
-    languageId: language.map((lang: {id: string}) => lang.id),
+    eventTagId: eventTags.map((tag: {id: string}) => tag.id),
+    eventTagName: eventTags.map((tag: {name: string}) => tag.name),
+    languageTagId: languageTag.map((tag: {id: string}) => tag.id),
     locale: locale,
   };
 
@@ -90,9 +90,9 @@ export const getSearch = async (
   return data;
 };
 
-export const getEventsTags = async (tagField: string ) => {
+export const getEventsTags = async (tagField: string, locale: string ) => {
   const { data } = await axios(`${EVENTS_TAGS_URL}`, {
-    params: { tagField: tagField},
+    params: { tagField: tagField, locale: locale},
   }); 
   return data;
 };

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -37,7 +37,6 @@ export const getEventsSearch = async (
   const queryParams = {
     index: eventsIndex,
     eventTagId: eventTags.map((tag: { id: string }) => tag.id),
-    eventTagName: eventTags.map((tag: { name: string }) => tag.name),
     languageTagId: languageTag.map((tag: { id: string }) => tag.id),
     locale: locale,
   };

--- a/src/lib/client-api.ts
+++ b/src/lib/client-api.ts
@@ -29,17 +29,23 @@ export const getEvents = async (queryParams: EventsQueryParams) => {
 export const getEventsSearch = async (
   eventsIndex: number,
   field_event_tags: string[] | null,
+  field_in_language: string[] | null,
   locale: Locale
-) => {  
-  const queryParams = {index: eventsIndex, filter: field_event_tags, locale: locale };
-  
+) => {
+  const queryParams = {
+    index: eventsIndex,
+    filter: field_event_tags,
+    languageFilter: field_in_language,
+    locale: locale,
+  };
+
   const { data } = await axios(`${EVENTS_SEARCH_URL}`, {
     params: queryParams,
     paramsSerializer: (params) => {
       return qs.stringify(params, { arrayFormat: 'repeat' });
-    }, 
+    },
   });
-  
+
   return data;
 };
 
@@ -82,12 +88,13 @@ export const getSearch = async (
   return data;
 };
 
-export const getEventsTags = async (tagField: string, locale: Locale, ) => {
+export const getEventsTags = async (tagField: string ) => {
   const { data } = await axios(`${EVENTS_TAGS_URL}`, {
-    params: { tagField: tagField, locale: locale},
-  });
+    params: { tagField: tagField},
+  }); 
   return data;
 };
+
 
 export const getSearchSuggestions = async (
   query: string | undefined,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,7 +37,7 @@ export const printablePages = [
 ];
 
 export const primaryLanguages = ['fi', 'en', 'sv'];
-export const drupalLanguages = ['fi', 'en', 'sv'];
+export const drupalLanguages = ['fi', 'en', 'sv', 'ua', 'ru', 'so'];
 export const frontPagePaths = [
   '/',
   '/en',

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,7 +37,7 @@ export const printablePages = [
 ];
 
 export const primaryLanguages = ['fi', 'en', 'sv'];
-export const drupalLanguages = ['fi', 'en', 'sv', 'so', 'ua', 'ru'];
+export const drupalLanguages = ['fi', 'en', 'sv'];
 export const frontPagePaths = [
   '/',
   '/en',
@@ -343,8 +343,8 @@ export const getInitialFilters = (filterName: string, locale: string) => {
 };
 
 export const handlePageURL = (
-  filter: string[],
-  languageFilter: any,
+  filter: [{name: string, id: string}],
+  languageFilter: [{name: string, id: string}],
   router: any,
   basePath: string
 ) => {
@@ -368,15 +368,17 @@ export const handlePageURL = (
   }
 };
 
-export const getAvailableTags = (events: EventData[], fieldName: string) => {
-  const availableTags: string[] = [];
+export const getAvailableTags = (events: EventData[], fieldName: string) => {  
+  const availableTags: string[] = [];  
   events
     ?.map((event: { [field: string]: any }) => event?.[fieldName])
     .forEach((field: string[]) =>
-      field?.forEach((tag: string) =>
+      field?.forEach((tag: string) =>      
         !availableTags.includes(tag) ? availableTags.push(tag) : null
       )
     );    
+    console.log('availableTags', availableTags);
+    
   return availableTags;
 };
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -311,7 +311,7 @@ export const getKey = (index: number) => {
   return `${index}`;
 };
 
-export const getContent = (content: string, data: any) => {  
+export const getContent = (content: string, data: any) => {
   /** Filter events object from data */
   return data?.reduce((acc: any, curr: any) => acc.concat(curr?.[content]), []);
 };
@@ -343,16 +343,24 @@ export const getInitialFilters = (filterName: string, locale: string) => {
 
 export const handlePageURL = (
   filter: string[],
+  languageFilter: string[],
   router: any,
   basePath: string
 ) => {
-  if (filter.length) {
+  if (filter.length || languageFilter.length) {
     const tags = filter.map((tag) =>
       tag === filter[0] ? `tag=${tag}` : `&tag=${tag}`
     );
+    const langTags = languageFilter.map((tag) =>
+      tag === languageFilter[0] && tags.length === 0
+        ? `lang=${tag}`
+        : `&lang=${tag}`
+    );
 
     router.replace(
-      `/${basePath}?${tags.toString().replaceAll(',', '')}`,
+      `/${basePath}?${tags.toString().replaceAll(',', '')}${langTags
+        .toString()
+        .replaceAll(',', '')}`,
       undefined,
       { shallow: true }
     );

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -343,7 +343,7 @@ if (urlParams !== null && urlParams.getAll(filterName).length !== 0) {
 };
 
 export const handlePageURL = (
-  filter: [{name: string, id: string}],
+  filter: [{name_en: string, id: string}],
   languageFilter: [{name: string, id: string}],
   router: any,
   basePath: string
@@ -353,7 +353,7 @@ export const handlePageURL = (
       if (typeof tag === 'string') {
       return  tag === filter[0] ? `tag=${tag}` : `&tag=${tag}`
       } else {
-       return tag === filter[0] ? `tag=${tag.name}` : `&tag=${tag.name}`
+       return tag === filter[0] ? `tag=${tag.name_en}` : `&tag=${tag.name_en}`
       }
       }
     );

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,6 +37,7 @@ export const printablePages = [
 ];
 
 export const primaryLanguages = ['fi', 'en', 'sv'];
+export const drupalLanguages = ['fi', 'en', 'sv', 'so', 'ua', 'ru'];
 export const frontPagePaths = [
   '/',
   '/en',
@@ -343,7 +344,7 @@ export const getInitialFilters = (filterName: string, locale: string) => {
 
 export const handlePageURL = (
   filter: string[],
-  languageFilter: string[],
+  languageFilter: any,
   router: any,
   basePath: string
 ) => {
@@ -351,10 +352,10 @@ export const handlePageURL = (
     const tags = filter.map((tag) =>
       tag === filter[0] ? `tag=${tag}` : `&tag=${tag}`
     );
-    const langTags = languageFilter.map((tag) =>
+    const langTags = languageFilter.map((tag :{ name: string}) =>
       tag === languageFilter[0] && tags.length === 0
-        ? `lang=${tag}`
-        : `&lang=${tag}`
+        ? `lang=${tag.name}`
+        : `&lang=${tag.name}`
     );
 
     router.replace(
@@ -375,7 +376,7 @@ export const getAvailableTags = (events: EventData[], fieldName: string) => {
       field?.forEach((tag: string) =>
         !availableTags.includes(tag) ? availableTags.push(tag) : null
       )
-    );
+    );    
   return availableTags;
 };
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -330,7 +330,6 @@ export const getInitialFilters = (filterName: string, locale: string) => {
 if (urlParams !== null && urlParams.getAll(filterName).length !== 0) {
   return urlParams.getAll(filterName);
 }
-    const sessionLocale = sessionStorage.getItem('locale');
     const sessionFilters = sessionStorage.getItem(filterName);    
     if (sessionFilters !== null) {
       return JSON.parse(sessionFilters);

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -327,12 +327,12 @@ export const getTotal = (data: EventData[]) => {
 
 export const getInitialFilters = (filterName: string, locale: string) => {
   if (typeof window !== 'undefined') {
-    if (urlParams !== null && urlParams.getAll(filterName).length !== 0) {
-      return urlParams.getAll(filterName);
-    }
+if (urlParams !== null && urlParams.getAll(filterName).length !== 0) {
+  return urlParams.getAll(filterName);
+}
     const sessionLocale = sessionStorage.getItem('locale');
-    const sessionFilters = sessionStorage.getItem(filterName);
-    if (sessionFilters !== null && sessionLocale === locale) {
+    const sessionFilters = sessionStorage.getItem(filterName);    
+    if (sessionFilters !== null) {
       return JSON.parse(sessionFilters);
     } else {
       return [];
@@ -348,15 +348,27 @@ export const handlePageURL = (
   router: any,
   basePath: string
 ) => {
-  if (filter.length || languageFilter.length) {
-    const tags = filter.map((tag) =>
-      tag === filter[0] ? `tag=${tag}` : `&tag=${tag}`
+  if (filter?.length || languageFilter?.length) {
+    const tags = filter?.map((tag) =>{
+      if (typeof tag === 'string') {
+      return  tag === filter[0] ? `tag=${tag}` : `&tag=${tag}`
+      } else {
+       return tag === filter[0] ? `tag=${tag.name}` : `&tag=${tag.name}`
+      }
+      }
     );
-    const langTags = languageFilter.map((tag :{ name: string}) =>
-      tag === languageFilter[0] && tags.length === 0
+    const langTags = languageFilter?.map((tag: { name: string }) => {
+      if (typeof tag === 'string') {
+        return tag === languageFilter[0] && tags.length === 0
+        ? `lang=${tag}`
+        : `&lang=${tag}`;
+      } else {
+       return tag === languageFilter[0] && tags.length === 0
         ? `lang=${tag.name}`
-        : `&lang=${tag.name}`
-    );
+        : `&lang=${tag.name}`;
+      }
+  
+    });
 
     router.replace(
       `/${basePath}?${tags.toString().replaceAll(',', '')}${langTags
@@ -377,8 +389,6 @@ export const getAvailableTags = (events: EventData[], fieldName: string) => {
         !availableTags.includes(tag) ? availableTags.push(tag) : null
       )
     );    
-    console.log('availableTags', availableTags);
-    
   return availableTags;
 };
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -357,15 +357,15 @@ export const handlePageURL = (
       }
       }
     );
-    const langTags = languageFilter?.map((tag: { name: string }) => {
+    const langTags = languageFilter?.map((tag: { id: string }) => {
       if (typeof tag === 'string') {
         return tag === languageFilter[0] && tags.length === 0
         ? `lang=${tag}`
         : `&lang=${tag}`;
       } else {
        return tag === languageFilter[0] && tags.length === 0
-        ? `lang=${tag.name}`
-        : `&lang=${tag.name}`;
+        ? `lang=${tag.id}`
+        : `&lang=${tag.id}`;
       }
   
     });

--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -205,11 +205,11 @@ export const baseEventQueryParams = () =>
       'field_location_extra_info',
       'field_offers_info_url',
       'field_event_tags',
+      'field_in_language',
       'field_provider',
       'field_super_event',
       'field_publisher',
       'field_provider',
-      'field_in_language'
     ])
 
 const getEventPageQueryParams = () =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,6 +125,7 @@ export interface EventData  {
   total: number;
   maxTotal?: number;
   field_in_language: string;
+  field_language_id: string;
   status: boolean;
   langcode: string[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,8 +125,9 @@ export interface EventData  {
   total: number;
   maxTotal?: number;
   field_in_language: string;
+  field_event_tags_id: string;
   field_language_id: string;
-  status: boolean;
+    status: boolean;
   langcode: string[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,6 +126,7 @@ export interface EventData  {
   maxTotal?: number;
   field_in_language: string;
   status: boolean;
+  langcode: string[];
 }
 
 export interface EventListProps {


### PR DESCRIPTION
### Changes
Changed event and tag fetches to use new event_index. Added language filter


- Testing with branch https://github.com/City-of-Helsinki/drupal-employment-services/pull/177


### Testing
- http://localhost:3000/ajankohtaista/tapahtumat

#### Language select

- Test first Select language.
- When selecting a Drupal language (fi, en, sv, ru, so, ua), the tags should change to the selected language, and you should receive the same data as you would on the local page. For example, if you are on Finnish pages and you choose English in the filter, you should receive the same data as you would on an English page.
- Additionally, the lang tag on URL  should also change to the selected language. 


#### Select Topic
- Keep a language selected and add topics.
- The "Select Topic" functionality should work as before.
- The URL tags should always be in English, even if your tags are displayed in Finnish on the UI.

#### Test Memory

- Select some filters. 
- Then select an event and open the event on the same page.
- Go back with the browser back button or breadcrumbs.
- You should end up in the same place with the same filters you left.
-
- Select again some filter. 
- Choose some filters again. Choose a Drupal language that is different from your local language.
- For example, if you are on a Finnish page, choose English.
- Then, select an event and open the event on the same page.
- Go back using the browser back button.
- You should end up on the same local page as you left.
- Go back to the event and use breadcrumbs to return to the Event page.
- You should end up on the local page of the language you had before on the language filter.
- The same filters should also be in place.

#### Test URL
- Select a language and some topics. Copy the URL and open a new tab. Paste the copied URL.
- You should now have the same filters as you had when you left the page.





